### PR TITLE
feat: #9 공통 예외에서 카테고리 예외 응답 구현하기

### DIFF
--- a/src/main/java/run/bemin/api/general/exception/ErrorCode.java
+++ b/src/main/java/run/bemin/api/general/exception/ErrorCode.java
@@ -33,8 +33,18 @@ public enum ErrorCode {
   INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST.value(), "S003", "이메일 형식이 올바르지 않습니다."),
   EMAIL_REQUIRED(HttpStatus.BAD_REQUEST.value(), "S004", "이메일을 입력해주세요."),
   INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST.value(), "S005", "닉네임 형식이 올바르지 않습니다."),
-  NICKNAME_REQUIRED(HttpStatus.BAD_REQUEST.value(), "S006", "닉네임을 입력해주세요.");
+  NICKNAME_REQUIRED(HttpStatus.BAD_REQUEST.value(), "S006", "닉네임을 입력해주세요."),
 
+  // Category (카테고리 관련 오류)
+  CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "CC001", "해당 카테고리를 찾을 수 없습니다."),
+  CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), "CC002", "이미 존재하는 카테고리입니다."),
+  CATEGORY_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "CC003", "카테고리 업데이트에 실패했습니다."),
+  CATEGORY_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "CC004", "카테고리 삭제에 실패했습니다."),
+  CATEGORY_NAME_INVALID(HttpStatus.BAD_REQUEST.value(), "CC005", "카테고리 이름이 유효하지 않습니다."),
+  CATEGORY_IS_ACTIVE_INVALID(HttpStatus.BAD_REQUEST.value(), "CC006", "카테고리 활성화 여부가 유효하지 않습니다."),
+  CATEGORY_PARENT_INVALID(HttpStatus.BAD_REQUEST.value(), "CC007", "부모 카테고리 ID가 유효하지 않습니다."),
+  CATEGORY_DISABLED(HttpStatus.FORBIDDEN.value(), "CC009", "비활성화된 카테리입니다."),
+  CATEGORY_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "CC010", "카테고리에 대한 권한이 없습니다.");
 
   private final int status;
   private final String code;


### PR DESCRIPTION
카테고리 예외 응답에 필요한 코드를 작성한다.

공통 로직 안에서 처리를 수행하기 때문에, 다른 팀원들과 충돌 가능성의 여지가 있는 것에 걱정이 든다.

공통 설계 부분에서 인터페이스로 분리하여 각 도메인마다 공통 로직을 갖도록 설계하는 방법이 떠오른다.

예를 들어,

ResponseCodeInterface 인터페이스를 상속받는 공통 응답 HttpResponse, ErrorResponse를 구현하여 공통 응답 뿐만 아니라 각 도메인마다 모두 일관된 응답과 각 도메인 성격에 맞는 예외 메시지를 던질 수 있고, 완전히 독립된 개발로 커밋 충돌의 여지를 없앨 수 있다는 생각이 든다.

## ⚙️ PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 🔑 Key Changes

-

<br/>

## 🤝🏻 To Reviewers

- @kim0527 @heejinkong @RTPC01 @kimseonhee126 

<br/>

