### PR TITLE
모든 카테고리 조회 API 구현하기 

### DIFF
--- a/src/main/java/run/bemin/BeminApplication.java
+++ b/src/main/java/run/bemin/BeminApplication.java
@@ -2,7 +2,10 @@ package run.bemin;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode;
 
+@EnableSpringDataWebSupport(pageSerializationMode = PageSerializationMode.VIA_DTO)
 @SpringBootApplication
 public class BeminApplication {
 

--- a/src/main/java/run/bemin/api/category/controller/AdminCategoryController.java
+++ b/src/main/java/run/bemin/api/category/controller/AdminCategoryController.java
@@ -1,23 +1,33 @@
 package run.bemin.api.category.controller;
 
+import static java.lang.Boolean.*;
+import static java.lang.Boolean.FALSE;
+import static run.bemin.api.category.dto.CategoryResponseCode.CATEGORIES_FETCHED;
+import static run.bemin.api.category.dto.CategoryResponseCode.CATEGORY_CREATED;
+
+import java.net.http.HttpResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import run.bemin.api.category.dto.CategoryDto;
+import run.bemin.api.category.dto.CategoryResponseCode;
 import run.bemin.api.category.dto.request.CreateCategoryRequestDto;
 import run.bemin.api.category.service.CategoryService;
 import run.bemin.api.general.response.ApiResponse;
 import run.bemin.api.security.UserDetailsImpl;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/category")
+@RequestMapping("/api/v1/admin/category")
 @RestController
 public class AdminCategoryController { // TODO: 권한 설정 필요하다.
 
@@ -28,10 +38,31 @@ public class AdminCategoryController { // TODO: 권한 설정 필요하다.
       @RequestBody CreateCategoryRequestDto requestDto) {
 
     return ResponseEntity
-        .status(HttpStatus.CREATED) // 201 Created 상태 코드
-        .body(ApiResponse.from(HttpStatus.CREATED, "카테고리 생성 성공",
+        .status(CATEGORY_CREATED.getStatus())
+        .body(ApiResponse.from(CATEGORY_CREATED.getStatus(), CATEGORY_CREATED.getMessage(),
             categoryService.createCategory(requestDto)));
   }
 
+  @GetMapping
+  public ResponseEntity<ApiResponse<Page<CategoryDto>>> getAllCategories(
+      @RequestParam(value = "name", required = false) String name,
+      @RequestParam(value = "isDeleted", required = false) Boolean isDeleted,
+      @RequestParam(value = "page", defaultValue = "0") Integer page,
+      @RequestParam(value = "size", defaultValue = "10") Integer size,
+      @RequestParam(value = "sortBy", defaultValue = "createdBy") String sortBy,
+      @RequestParam(value = "isAsc", defaultValue = "true") Boolean isAsc
+  ) {
+    Page<CategoryDto> categories = categoryService.getAllCategories(
+        name,
+        isDeleted,
+        page,
+        size,
+        sortBy,
+        isAsc,
+        true);
+
+    return ResponseEntity.ok(
+        ApiResponse.from(CATEGORIES_FETCHED.getStatus(), CATEGORIES_FETCHED.getMessage(), categories));
+  }
 
 }

--- a/src/main/java/run/bemin/api/category/controller/CategoryController.java
+++ b/src/main/java/run/bemin/api/category/controller/CategoryController.java
@@ -1,6 +1,44 @@
 package run.bemin.api.category.controller;
 
 
+import static run.bemin.api.category.dto.CategoryResponseCode.CATEGORIES_FETCHED;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import run.bemin.api.category.dto.CategoryDto;
+import run.bemin.api.category.service.CategoryService;
+import run.bemin.api.general.response.ApiResponse;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/category")
+@RestController
 public class CategoryController {
+
+  private final CategoryService categoryService;
+
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<Page<CategoryDto>>> getAllCategories(
+      @RequestParam(value = "page", defaultValue = "0") Integer page,
+      @RequestParam(value = "size", defaultValue = "10") Integer size
+  ) {
+    Page<CategoryDto> categories = categoryService.getAllCategories(
+        null,
+        false,
+        page,
+        size,
+        "createdAt",
+        true,
+        false);
+
+    return ResponseEntity.ok(
+        ApiResponse.from(CATEGORIES_FETCHED.getStatus(), CATEGORIES_FETCHED.getMessage(), categories));
+  }
+
 
 }

--- a/src/main/java/run/bemin/api/category/dto/CategoryDto.java
+++ b/src/main/java/run/bemin/api/category/dto/CategoryDto.java
@@ -1,5 +1,6 @@
 package run.bemin.api.category.dto;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 import run.bemin.api.category.entity.Category;
 
@@ -9,10 +10,11 @@ public record CategoryDto(
     Boolean isDeleted,
     String createdBy,
     String updatedBy,
-    String deletedBy
+    String deletedBy,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    LocalDateTime deletedAt
 ) {
-
-  // TODO: 추후에 isDeleted, createdBy, UpdatedBy, DeletedBy 는 권한 확인 후 수정할 수 있도록 수정하기
   public static CategoryDto fromEntity(Category category) {
     return new CategoryDto(
         category.getId(),
@@ -20,9 +22,10 @@ public record CategoryDto(
         category.getIsDeleted(),
         category.getCreatedBy(),
         category.getUpdatedBy(),
-        category.getDeletedBy()
+        category.getDeletedBy(),
+        category.getCreatedAt(),
+        category.getUpdatedAt(),
+        category.getDeletedAt()
     );
   }
-
-
 }

--- a/src/main/java/run/bemin/api/category/dto/CategoryResponseCode.java
+++ b/src/main/java/run/bemin/api/category/dto/CategoryResponseCode.java
@@ -1,0 +1,26 @@
+package run.bemin.api.category.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum CategoryResponseCode {
+
+  // 카테고리 응답 코드 Category Success
+  SUCCESS(HttpStatus.OK, "CCS000", "요청이 성공적으로 처리되었습니다."),
+  CATEGORY_CREATED(HttpStatus.CREATED, "CCS001", "카테고리 등록에 성공했습니다."),
+  CATEGORY_UPDATED(HttpStatus.OK, "CCS002", "카테고리 정보가 수정되었습니다."),
+  CATEGORY_DELETED(HttpStatus.OK, "CCS003", "카테고리가 삭제되었습니다."),
+  CATEGORY_FETCHED(HttpStatus.OK, "CCS004", "카테고리 정보를 성공적으로 조회했습니다."),
+  CATEGORIES_FETCHED(HttpStatus.OK, "CCS005", "전체 카테고리 목록을 성공적으로 조회했습니다.");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+
+  public int getStatusCode() {
+    return status.value();
+  }
+}

--- a/src/main/java/run/bemin/api/category/dto/CategoryValidationMessages.java
+++ b/src/main/java/run/bemin/api/category/dto/CategoryValidationMessages.java
@@ -1,4 +1,4 @@
-package run.bemin.api.category.exception.validation;
+package run.bemin.api.category.dto;
 
 public class CategoryValidationMessages {
 

--- a/src/main/java/run/bemin/api/category/dto/request/CreateCategoryRequestDto.java
+++ b/src/main/java/run/bemin/api/category/dto/request/CreateCategoryRequestDto.java
@@ -1,9 +1,9 @@
 package run.bemin.api.category.dto.request;
 
-import static run.bemin.api.category.exception.validation.CategoryValidationMessages.CATEGORY_NAME_BLANK;
-import static run.bemin.api.category.exception.validation.CategoryValidationMessages.CATEGORY_NAME_INVALID;
-import static run.bemin.api.category.exception.validation.CategoryValidationMessages.USER_EMAIL_BLANK;
-import static run.bemin.api.category.exception.validation.CategoryValidationMessages.USER_EMAIL_INVALID;
+import static run.bemin.api.category.dto.CategoryValidationMessages.CATEGORY_NAME_BLANK;
+import static run.bemin.api.category.dto.CategoryValidationMessages.CATEGORY_NAME_INVALID;
+import static run.bemin.api.category.dto.CategoryValidationMessages.USER_EMAIL_BLANK;
+import static run.bemin.api.category.dto.CategoryValidationMessages.USER_EMAIL_INVALID;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;

--- a/src/main/java/run/bemin/api/category/entity/Category.java
+++ b/src/main/java/run/bemin/api/category/entity/Category.java
@@ -7,6 +7,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -26,7 +29,7 @@ public class Category {
   @Column(name = "name", nullable = false, unique = true)
   private String name;
 
-  @Column(name = "is_active", nullable = false)
+  @Column(name = "is_deleted", nullable = false)
   @ColumnDefault("true")
   private Boolean isDeleted;
 
@@ -39,33 +42,60 @@ public class Category {
   @Column(name = "deleted_by", nullable = true)
   private String deletedBy;
 
-  private Category(
-      String name,
-      String createdBy,
-      Boolean isDeleted,
-      String updatedBy,
-      String deletedBy) {
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = true)
+  private LocalDateTime updatedAt;
+
+  @Column(name = "deleted_at", nullable = true)
+  private LocalDateTime deletedAt;
+
+  private Category(String name, Boolean isDeleted, String createdBy, String updatedBy, String deletedBy,
+                   LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
     this.name = name;
     this.isDeleted = isDeleted;
     this.createdBy = createdBy;
     this.updatedBy = updatedBy;
     this.deletedBy = deletedBy;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.deletedAt = deletedAt;
   }
 
-  public static Category create(
-      String name,
-      String createdBy) {
-    return new Category(name, createdBy, FALSE, null, null);
+  public static Category create(String name, String createdBy) {
+    return new Category(
+        name,
+        false,
+        createdBy,
+        null,
+        null,
+        LocalDateTime.now(),
+        null,
+        null);
   }
 
   public void update(String updatedBy, String name, Boolean isDeleted) {
     this.updatedBy = updatedBy;
     this.name = name;
     this.isDeleted = isDeleted != null ? isDeleted : this.isDeleted;
+    this.updatedAt = LocalDateTime.now();
   }
 
   public void delete(String deletedBy) {
     this.deletedBy = deletedBy;
+    this.isDeleted = true;
+    this.deletedAt = LocalDateTime.now();
+  }
+
+  @PrePersist
+  protected void onCreate() {
+    this.createdAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = LocalDateTime.now();
   }
 
 

--- a/src/main/java/run/bemin/api/category/repository/CategoryRepository.java
+++ b/src/main/java/run/bemin/api/category/repository/CategoryRepository.java
@@ -3,10 +3,18 @@ package run.bemin.api.category.repository;
 
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 import run.bemin.api.category.entity.Category;
 
 public interface CategoryRepository extends CrudRepository<Category, UUID> {
 
   Boolean existsCategoryByName(String name);
+
+  Page<Category> findAll(Pageable pageable);
+
+  Page<Category> findAllByIsDeleted(Boolean isDeleted, Pageable pageable);
+
+  Page<Category> findAllByIsDeletedAndNameContainingIgnoreCase(Boolean isDeleted, String name, Pageable pageable);
 }

--- a/src/main/java/run/bemin/api/category/service/CategoryService.java
+++ b/src/main/java/run/bemin/api/category/service/CategoryService.java
@@ -1,6 +1,11 @@
 package run.bemin.api.category.service;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import run.bemin.api.category.dto.CategoryDto;
@@ -33,4 +38,25 @@ public class CategoryService { // TODO: 회원 등록 유무/권한 체크 기�
     return CategoryDto.fromEntity(category);
   }
 
+
+  @Transactional(readOnly = true)
+  public Page<CategoryDto> getAllCategories(
+      String name, Boolean isDeleted, Integer page, Integer size, String sortBy, Boolean isAsc, Boolean isAdmin) {
+
+    Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+    Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
+
+    if (isAdmin) {
+      // 관리자: 삭제 여부 무관하게 전체 조회
+      return categoryRepository.findAll(pageable).map(CategoryDto::fromEntity);
+    }
+
+    // 일반 사용자: 삭제되지 않은 카테고리만 조회
+    Boolean filterDeleted = Optional.ofNullable(isDeleted).orElse(false);
+    Page<Category> categoryPage = (name != null)
+        ? categoryRepository.findAllByIsDeletedAndNameContainingIgnoreCase(filterDeleted, name, pageable)
+        : categoryRepository.findAllByIsDeleted(filterDeleted, pageable);
+
+    return categoryPage.map(CategoryDto::fromEntity);
+  }
 }


### PR DESCRIPTION
카테고리 조회는 크게 CUSTOMER 그리고 OWNER, MASTER, MANAGER 권한 유무로 API를 분리했습니다.

모든 정보를 CUSTOMER 에게 제공하지 않게끔, 적절한 권한에 따라 카테고리 조회를 제공하고 있습니다. 
예를 들어, 삭제된 카테고리는 CUSTOMER 가 조회할 수 없지만 OWNER, MANAGER, MASTER는 조회가 가능합니다.

Spring Boot 3.3 이상부터 Page 인터페이스 직렬화 문제로 인해 새롭게 등장한 애너테이션을 추가했습니다.
다음과 같이 이전과 다르게 페이정 정보에서 다른 점이 있습니다.

![image](https://github.com/user-attachments/assets/7111bc24-20cd-4da4-ba86-44b31de275fa)


## ⚙️ PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 🔑 Key Changes

-

<br/>

## 🤝🏻 To Reviewers

- This closes #16

<br/>

