### PR TITLE
특정 카테고리 수정/삭제 구현하기

### DIFF
--- a/src/main/java/run/bemin/api/category/controller/AdminCategoryController.java
+++ b/src/main/java/run/bemin/api/category/controller/AdminCategoryController.java
@@ -1,30 +1,27 @@
 package run.bemin.api.category.controller;
 
-import static java.lang.Boolean.*;
-import static java.lang.Boolean.FALSE;
 import static run.bemin.api.category.dto.CategoryResponseCode.CATEGORIES_FETCHED;
 import static run.bemin.api.category.dto.CategoryResponseCode.CATEGORY_CREATED;
+import static run.bemin.api.category.dto.CategoryResponseCode.CATEGORY_DELETED;
+import static run.bemin.api.category.dto.CategoryResponseCode.CATEGORY_UPDATED;
 
-import java.net.http.HttpResponse;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import run.bemin.api.category.dto.CategoryDto;
-import run.bemin.api.category.dto.CategoryResponseCode;
 import run.bemin.api.category.dto.request.CreateCategoryRequestDto;
+import run.bemin.api.category.dto.request.SoftDeleteCategoryRequestDto;
+import run.bemin.api.category.dto.request.UpdateCategoryRequestDto;
 import run.bemin.api.category.service.CategoryService;
 import run.bemin.api.general.response.ApiResponse;
-import run.bemin.api.security.UserDetailsImpl;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/category")
@@ -36,11 +33,10 @@ public class AdminCategoryController { // TODO: 권한 설정 필요하다.
   @PostMapping
   public ResponseEntity<ApiResponse<CategoryDto>> createCategory(
       @RequestBody CreateCategoryRequestDto requestDto) {
-
+    CategoryDto categoryDto = categoryService.createCategory(requestDto);
     return ResponseEntity
         .status(CATEGORY_CREATED.getStatus())
-        .body(ApiResponse.from(CATEGORY_CREATED.getStatus(), CATEGORY_CREATED.getMessage(),
-            categoryService.createCategory(requestDto)));
+        .body(ApiResponse.from(CATEGORY_CREATED.getStatus(), CATEGORY_CREATED.getMessage(), categoryDto));
   }
 
   @GetMapping
@@ -65,4 +61,21 @@ public class AdminCategoryController { // TODO: 권한 설정 필요하다.
         ApiResponse.from(CATEGORIES_FETCHED.getStatus(), CATEGORIES_FETCHED.getMessage(), categories));
   }
 
+  @PatchMapping
+  public ResponseEntity<ApiResponse<CategoryDto>> updateCategory(@RequestBody UpdateCategoryRequestDto requestDto) {
+    CategoryDto categoryDto = categoryService.updatedCategory(requestDto);
+
+    return ResponseEntity
+        .status(CATEGORY_UPDATED.getStatus())
+        .body(ApiResponse.from(CATEGORY_UPDATED.getStatus(), CATEGORY_UPDATED.getMessage(), categoryDto));
+  }
+
+  @DeleteMapping
+  public ResponseEntity<ApiResponse<CategoryDto>> softDeleteCategory(@RequestBody SoftDeleteCategoryRequestDto requestDto) {
+    CategoryDto categoryDto = categoryService.softDeleteCategory(requestDto);
+
+    return ResponseEntity
+        .status(CATEGORY_DELETED.getStatus())
+        .body(ApiResponse.from(CATEGORY_DELETED.getStatus(), CATEGORY_DELETED.getMessage(), categoryDto));
+  }
 }

--- a/src/main/java/run/bemin/api/category/dto/CategoryResponseCode.java
+++ b/src/main/java/run/bemin/api/category/dto/CategoryResponseCode.java
@@ -12,9 +12,10 @@ public enum CategoryResponseCode {
   SUCCESS(HttpStatus.OK, "CCS000", "요청이 성공적으로 처리되었습니다."),
   CATEGORY_CREATED(HttpStatus.CREATED, "CCS001", "카테고리 등록에 성공했습니다."),
   CATEGORY_UPDATED(HttpStatus.OK, "CCS002", "카테고리 정보가 수정되었습니다."),
-  CATEGORY_DELETED(HttpStatus.OK, "CCS003", "카테고리가 삭제되었습니다."),
+  CATEGORY_DELETED(HttpStatus.OK, "CCS003", "카테고리가 소프트 삭제되었습니다."),
   CATEGORY_FETCHED(HttpStatus.OK, "CCS004", "카테고리 정보를 성공적으로 조회했습니다."),
-  CATEGORIES_FETCHED(HttpStatus.OK, "CCS005", "전체 카테고리 목록을 성공적으로 조회했습니다.");
+  CATEGORIES_FETCHED(HttpStatus.OK, "CCS005", "전체 카테고리 목록을 성공적으로 조회했습니다."),
+  CATEGORY_DELETED_HARD(HttpStatus.OK, "CCS006", "카테고리가 하드 삭제되었습니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/run/bemin/api/category/dto/request/SoftDeleteCategoryRequestDto.java
+++ b/src/main/java/run/bemin/api/category/dto/request/SoftDeleteCategoryRequestDto.java
@@ -1,0 +1,9 @@
+package run.bemin.api.category.dto.request;
+
+import java.util.UUID;
+
+public record SoftDeleteCategoryRequestDto(
+    String userEmail,
+    UUID categoryId
+) {
+}

--- a/src/main/java/run/bemin/api/category/dto/request/UpdateCategoryRequestDto.java
+++ b/src/main/java/run/bemin/api/category/dto/request/UpdateCategoryRequestDto.java
@@ -1,0 +1,11 @@
+package run.bemin.api.category.dto.request;
+
+import java.util.UUID;
+
+public record UpdateCategoryRequestDto(
+    String userEmail,
+    UUID categoryId,
+    String name,
+    Boolean isDeleted
+) {
+}

--- a/src/main/java/run/bemin/api/category/entity/Category.java
+++ b/src/main/java/run/bemin/api/category/entity/Category.java
@@ -1,7 +1,5 @@
 package run.bemin.api.category.entity;
 
-import static java.lang.Boolean.FALSE;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -82,10 +80,12 @@ public class Category {
     this.updatedAt = LocalDateTime.now();
   }
 
-  public void delete(String deletedBy) {
+  public void softDelete(String deletedBy) {
     this.deletedBy = deletedBy;
     this.isDeleted = true;
     this.deletedAt = LocalDateTime.now();
+    this.updatedAt = LocalDateTime.now();
+    this.updatedBy = deletedBy;
   }
 
   @PrePersist

--- a/src/main/java/run/bemin/api/category/exception/handler/CategoryExceptionHandler.java
+++ b/src/main/java/run/bemin/api/category/exception/handler/CategoryExceptionHandler.java
@@ -17,8 +17,10 @@ public class CategoryExceptionHandler {
 
   @ExceptionHandler(CategoryNotFoundException.class)
   public ResponseEntity<ErrorResponse> CategoryNotFoundException(CategoryNotFoundException e) {
+    List<FieldError> errors = FieldError.of("id", e.getMessage(), CATEGORY_NOT_FOUND.getMessage());
+
     return ResponseEntity.status(CATEGORY_NOT_FOUND.getStatus())
-        .body(ErrorResponse.of(CATEGORY_NOT_FOUND));
+        .body(ErrorResponse.of(CATEGORY_NOT_FOUND, errors));
   }
 
   @ExceptionHandler(CategoryNameInvalidException.class)

--- a/src/main/java/run/bemin/api/category/repository/CategoryRepository.java
+++ b/src/main/java/run/bemin/api/category/repository/CategoryRepository.java
@@ -1,7 +1,6 @@
 package run.bemin.api.category.repository;
 
 
-import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/run/bemin/api/category/service/CategoryService.java
+++ b/src/main/java/run/bemin/api/category/service/CategoryService.java
@@ -10,8 +10,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import run.bemin.api.category.dto.CategoryDto;
 import run.bemin.api.category.dto.request.CreateCategoryRequestDto;
+import run.bemin.api.category.dto.request.SoftDeleteCategoryRequestDto;
+import run.bemin.api.category.dto.request.UpdateCategoryRequestDto;
 import run.bemin.api.category.entity.Category;
 import run.bemin.api.category.exception.CategoryAlreadyExistsByNameException;
+import run.bemin.api.category.exception.CategoryNotFoundException;
 import run.bemin.api.category.repository.CategoryRepository;
 
 @RequiredArgsConstructor
@@ -58,5 +61,30 @@ public class CategoryService { // TODO: 회원 등록 유무/권한 체크 기�
         : categoryRepository.findAllByIsDeleted(filterDeleted, pageable);
 
     return categoryPage.map(CategoryDto::fromEntity);
+  }
+
+  @Transactional
+  public CategoryDto updatedCategory(UpdateCategoryRequestDto requestDto) {
+    existsCategoryByName(requestDto.name());
+
+    Category category = categoryRepository.findById(requestDto.categoryId())
+        .orElseThrow(() -> new CategoryNotFoundException(requestDto.categoryId().toString()));
+
+    category.update(requestDto.userEmail(), requestDto.name(), requestDto.isDeleted());
+    Category savedCategory = categoryRepository.save(category);
+
+    return CategoryDto.fromEntity(savedCategory);
+  }
+
+
+  @Transactional
+  public CategoryDto softDeleteCategory(SoftDeleteCategoryRequestDto requestDto) {
+    Category category = categoryRepository.findById(requestDto.categoryId())
+        .orElseThrow(() -> new CategoryNotFoundException(requestDto.categoryId().toString()));
+
+    category.softDelete(requestDto.userEmail());
+    Category softDeletedCategory = categoryRepository.save(category);
+
+    return CategoryDto.fromEntity(softDeletedCategory);
   }
 }


### PR DESCRIPTION
지금은 모두 단순한 수정/삭제 API 이다. 회원 기능이 구현되면 각 권한마다 세부적인 수정/삭제를 할 수 있도록 구현이 반드시 필요합니다.

카테고리는 소프트 삭제와 하드 삭제 두 가지가 있다. RFP에서는 삭제는 절대 못하도록 막는 것을 원칙이기 때문에 DELETED 이름 그대로 사용하고, 컨트롤러에서는 애너테이션도 DELETED로 사용했습니다.

하드 삭제를 정확하게 명시하기 위해서 HARD 를 뒤에 붙이고, 메시지에서도 표시했습니다.

예외는 카테고리 존재 유무에 따라 errors 포함하여 응답을 던질 수 있도록 구현했습니다. 

delete 보다는 명시적으로 표현하기 위해 softDelete로 변경했습니다. 
또한 삭제자, 삭제일자 뿐만 아니라 수정자, 수정일자도 함께 수정해야 올바른 감사가 맞기 때문에 함께 수정되도록 코드를 수정했습니다.

## ⚙️ PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 🔑 Key Changes

-

<br/>

## 🤝🏻 To Reviewers

- This closes #17 

<br/>

