### PR TITLE
가게 엔티티 및 등록 API 구현하기

### DIFF
--- a/src/main/java/run/bemin/api/general/exception/ErrorCode.java
+++ b/src/main/java/run/bemin/api/general/exception/ErrorCode.java
@@ -44,7 +44,20 @@ public enum ErrorCode {
   CATEGORY_IS_ACTIVE_INVALID(HttpStatus.BAD_REQUEST.value(), "CC006", "카테고리 활성화 여부가 유효하지 않습니다."),
   CATEGORY_PARENT_INVALID(HttpStatus.BAD_REQUEST.value(), "CC007", "부모 카테고리 ID가 유효하지 않습니다."),
   CATEGORY_DISABLED(HttpStatus.FORBIDDEN.value(), "CC009", "비활성화된 카테리입니다."),
-  CATEGORY_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "CC010", "카테고리에 대한 권한이 없습니다.");
+  CATEGORY_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "CC010", "카테고리에 대한 권한이 없습니다."),
+
+  // Store (가게 관련 오류)
+  STORE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ST001", "해당 가게를 찾을 수 없습니다."),
+  STORE_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), "ST002", "이미 존재하는 가게입니다."),
+  STORE_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "ST003", "가게 정보 업데이트에 실패했습니다."),
+  STORE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "ST004", "가게 삭제에 실패했습니다."),
+  STORE_NAME_INVALID(HttpStatus.BAD_REQUEST.value(), "ST005", "가게 이름이 유효하지 않습니다."),
+  STORE_PHONE_INVALID(HttpStatus.BAD_REQUEST.value(), "ST006", "가게 전화번호가 유효하지 않습니다."),
+  STORE_MINIMUM_PRICE_INVALID(HttpStatus.BAD_REQUEST.value(), "ST007", "최소 주문 금액이 유효하지 않습니다."),
+  STORE_RATING_INVALID(HttpStatus.BAD_REQUEST.value(), "ST008", "가게 평점이 유효하지 않습니다."),
+  STORE_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "ST009", "가게에 대한 권한이 없습니다."),
+  STORE_DISABLED(HttpStatus.FORBIDDEN.value(), "ST010", "비활성화된 가게입니다.");
+
 
   private final int status;
   private final String code;

--- a/src/main/java/run/bemin/api/store/controller/AdminStoreController.java
+++ b/src/main/java/run/bemin/api/store/controller/AdminStoreController.java
@@ -1,0 +1,46 @@
+package run.bemin.api.store.controller;
+
+import static run.bemin.api.store.dto.StoreResponseCode.STORE_CREATED;
+import static run.bemin.api.store.dto.StoreResponseCode.STORE_FETCHED;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import run.bemin.api.general.response.ApiResponse;
+import run.bemin.api.store.dto.StoreDto;
+import run.bemin.api.store.dto.request.CreateStoreRequestDto;
+import run.bemin.api.store.service.StoreService;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/store")
+@RestController
+public class AdminStoreController {
+
+  private final StoreService storeService;
+
+  @GetMapping("/{storeName}")
+  public ResponseEntity<ApiResponse<Boolean>> existsStoreName(@PathVariable String storeName) {
+    Boolean existsStoreByName = storeService.existsStoreByName(storeName);
+
+    return ResponseEntity
+        .status(STORE_FETCHED.getStatus())
+        .body(ApiResponse.from(STORE_FETCHED.getStatus(), STORE_FETCHED.getMessage(), existsStoreByName));
+  }
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<StoreDto>> createStore(
+      @RequestBody CreateStoreRequestDto requestDto) {
+    StoreDto storeDto = storeService.createStore(requestDto);
+
+    return ResponseEntity
+        .status(STORE_CREATED.getStatus())
+        .body(ApiResponse.from(STORE_CREATED.getStatus(), STORE_CREATED.getMessage(), storeDto));
+  }
+
+
+}

--- a/src/main/java/run/bemin/api/store/controller/StoreController.java
+++ b/src/main/java/run/bemin/api/store/controller/StoreController.java
@@ -1,0 +1,16 @@
+package run.bemin.api.store.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import run.bemin.api.store.service.StoreService;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/store")
+@RestController
+public class StoreController {
+
+  private final StoreService storeService;
+
+
+}

--- a/src/main/java/run/bemin/api/store/dto/StoreDto.java
+++ b/src/main/java/run/bemin/api/store/dto/StoreDto.java
@@ -1,0 +1,40 @@
+package run.bemin.api.store.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import run.bemin.api.store.entity.Store;
+
+public record StoreDto(
+    UUID id,
+    String name,
+    String phone,
+    Integer minimumPrice,
+    Float rating,
+    Boolean isDeleted,
+    String createdBy,
+    String updatedBy,
+    String deletedBy,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    LocalDateTime deletedAt
+) {
+
+  public static StoreDto fromEntity(Store store) {
+    return new StoreDto(
+        store.getId(),
+        store.getName(),
+        store.getPhone(),
+        store.getMinimumPrice(),
+        store.getRating(),
+        store.getIsDeleted(),
+        store.getCreatedBy(),
+        store.getUpdatedBy(),
+        store.getDeletedBy(),
+        store.getCreatedAt(),
+        store.getUpdatedAt(),
+        store.getDeletedAt()
+    );
+  }
+
+
+}

--- a/src/main/java/run/bemin/api/store/dto/StoreResponseCode.java
+++ b/src/main/java/run/bemin/api/store/dto/StoreResponseCode.java
@@ -1,0 +1,26 @@
+package run.bemin.api.store.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum StoreResponseCode {
+
+  SUCCESS(HttpStatus.OK, "STS000", "요청이 성공적으로 처리되었습니다."),
+  STORE_CREATED(HttpStatus.CREATED, "STS001", "가게 등록에 성공했습니다."),
+  STORE_UPDATED(HttpStatus.OK, "STS002", "가게 정보가 수정되었습니다."),
+  STORE_DELETED(HttpStatus.OK, "STS003", "가게가 소프트 삭제되었습니다."),
+  STORE_FETCHED(HttpStatus.OK, "STS004", "가게 정보를 성공적으로 조회했습니다."),
+  STORES_FETCHED(HttpStatus.OK, "STS005", "전체 가게 목록을 성공적으로 조회했습니다."),
+  STORE_DELETED_HARD(HttpStatus.OK, "STS006", "가게가 하드 삭제되었습니다.");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+
+  public int getStatusCode() {
+    return status.value();
+  }
+}

--- a/src/main/java/run/bemin/api/store/dto/StoreValidationMessages.java
+++ b/src/main/java/run/bemin/api/store/dto/StoreValidationMessages.java
@@ -1,0 +1,16 @@
+package run.bemin.api.store.dto;
+
+public class StoreValidationMessages {
+
+  public static final String STORE_NAME_BLANK = "가게 이름: 필수 정보입니다.";
+  public static final String STORE_NAME_INVALID = "가게 이름은 한글, 영문, 숫자, 특수 문자(·, !), 공백만 입력 가능하며, 1~50글자 이내여야 합니다.";
+
+  public static final String STORE_PHONE_BLANK = "가게 전화번호: 필수 정보입니다.";
+  public static final String STORE_PHONE_INVALID = "가게 전화번호는 숫자와 '-' 기호만 입력 가능합니다.";
+
+  public static final String STORE_MINIMUM_PRICE_BLANK = "최소 주문 금액: 필수 정보입니다.";
+  public static final String STORE_MINIMUM_PRICE_INVALID = "최소 주문 금액은 0원 이상이어야 합니다.";
+
+  public static final String STORE_IS_ACTIVE_BLANK = "가게 활성화 여부: 필수 정보입니다.";
+
+}

--- a/src/main/java/run/bemin/api/store/dto/request/CreateStoreRequestDto.java
+++ b/src/main/java/run/bemin/api/store/dto/request/CreateStoreRequestDto.java
@@ -1,0 +1,29 @@
+package run.bemin.api.store.dto.request;
+
+import static run.bemin.api.store.dto.StoreValidationMessages.*;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record CreateStoreRequestDto(
+    @NotBlank(message = STORE_NAME_BLANK)
+    @Pattern(
+        regexp = "^[a-zA-Z가-힣0-9\\s]{1,36}$",
+        message = STORE_NAME_INVALID
+    )
+    String name,
+
+    @NotBlank(message = STORE_PHONE_BLANK)
+    @Pattern(
+        regexp = "^\\d{10,11}$",
+        message = STORE_PHONE_INVALID
+    )
+    String phone,
+
+    @Min(value = 0, message = STORE_MINIMUM_PRICE_INVALID)
+    Integer minimumPrice,
+
+    String userEmail
+) {
+}

--- a/src/main/java/run/bemin/api/store/entity/Store.java
+++ b/src/main/java/run/bemin/api/store/entity/Store.java
@@ -1,0 +1,70 @@
+package run.bemin.api.store.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "p_store")
+public class Store {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "category_id", nullable = false, updatable = false, unique = true)
+  private UUID id;
+
+  @Column(name = "name", nullable = false)
+  private String name;
+
+  @Column(name = "phone", nullable = true)
+  private String phone;
+
+  @Column(name = "minimum_price")
+  private Integer minimumPrice;
+
+  @Column(name = "rating")
+  private Float rating;
+
+  @Column(name = "is_deleted")
+  private Boolean isDeleted;
+
+  @Column(name = "created_by", updatable = false)
+  private String createdBy;
+
+  @Column(name = "updated_by", nullable = true)
+  private String updatedBy;
+
+  @Column(name = "deleted_by", nullable = true)
+  private String deletedBy;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = true)
+  private LocalDateTime updatedAt;
+
+  @Column(name = "deleted_at", nullable = true)
+  private LocalDateTime deletedAt;
+
+  private Store(String name, String phone, Integer minimumPrice, String createdBy) {
+    this.name = name;
+    this.phone = phone;
+    this.minimumPrice = minimumPrice;
+    this.isDeleted = false;
+    this.createdBy = createdBy;
+    this.createdAt = LocalDateTime.now();
+  }
+
+  public static Store create(String name, String phone, Integer minimumPrice, String createdBy) {
+    return new Store(name, phone, minimumPrice, createdBy);
+  }
+}

--- a/src/main/java/run/bemin/api/store/exception/StoreAlreadyExistsByNameException.java
+++ b/src/main/java/run/bemin/api/store/exception/StoreAlreadyExistsByNameException.java
@@ -1,0 +1,8 @@
+package run.bemin.api.store.exception;
+
+public class StoreAlreadyExistsByNameException extends RuntimeException {
+
+    public StoreAlreadyExistsByNameException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/run/bemin/api/store/exception/StoreNameInvalidException.java
+++ b/src/main/java/run/bemin/api/store/exception/StoreNameInvalidException.java
@@ -1,0 +1,8 @@
+package run.bemin.api.store.exception;
+
+public class StoreNameInvalidException extends RuntimeException {
+
+  public StoreNameInvalidException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/run/bemin/api/store/exception/StoreNotFoundException.java
+++ b/src/main/java/run/bemin/api/store/exception/StoreNotFoundException.java
@@ -1,0 +1,8 @@
+package run.bemin.api.store.exception;
+
+public class StoreNotFoundException extends RuntimeException {
+
+  public StoreNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/run/bemin/api/store/exception/handler/StoreExceptionHandler.java
+++ b/src/main/java/run/bemin/api/store/exception/handler/StoreExceptionHandler.java
@@ -1,0 +1,41 @@
+package run.bemin.api.store.exception.handler;
+
+import static run.bemin.api.general.exception.ErrorCode.CATEGORY_ALREADY_EXISTS;
+import static run.bemin.api.general.exception.ErrorCode.CATEGORY_NAME_INVALID;
+import static run.bemin.api.general.exception.ErrorCode.CATEGORY_NOT_FOUND;
+
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import run.bemin.api.general.exception.ErrorResponse;
+import run.bemin.api.general.exception.ErrorResponse.FieldError;
+import run.bemin.api.store.exception.StoreAlreadyExistsByNameException;
+import run.bemin.api.store.exception.StoreNameInvalidException;
+import run.bemin.api.store.exception.StoreNotFoundException;
+
+@RestControllerAdvice
+public class StoreExceptionHandler {
+
+  @ExceptionHandler(StoreNotFoundException.class)
+  public ResponseEntity<ErrorResponse> CategoryNotFoundException(StoreNotFoundException e) {
+    List<FieldError> errors = FieldError.of("id", e.getMessage(), CATEGORY_NOT_FOUND.getMessage());
+
+    return ResponseEntity.status(CATEGORY_NOT_FOUND.getStatus())
+        .body(ErrorResponse.of(CATEGORY_NOT_FOUND, errors));
+  }
+
+  @ExceptionHandler(StoreNameInvalidException.class)
+  public ResponseEntity<ErrorResponse> CategoryNameInvalidException(StoreNameInvalidException e) {
+    return ResponseEntity.status(CATEGORY_NAME_INVALID.getStatus())
+        .body(ErrorResponse.of(CATEGORY_NAME_INVALID));
+  }
+
+  @ExceptionHandler(StoreAlreadyExistsByNameException.class)
+  public ResponseEntity<ErrorResponse> CategoryAlreadyExistsByNameException(StoreAlreadyExistsByNameException e) {
+    List<FieldError> errors = FieldError.of("name", e.getMessage(), CATEGORY_ALREADY_EXISTS.getMessage());
+
+    return ResponseEntity.status(CATEGORY_ALREADY_EXISTS.getStatus())
+        .body(ErrorResponse.of(CATEGORY_ALREADY_EXISTS, errors));
+  }
+}

--- a/src/main/java/run/bemin/api/store/repository/StoreRepository.java
+++ b/src/main/java/run/bemin/api/store/repository/StoreRepository.java
@@ -1,0 +1,9 @@
+package run.bemin.api.store.repository;
+
+import java.util.UUID;
+import org.springframework.data.repository.CrudRepository;
+import run.bemin.api.store.entity.Store;
+
+public interface StoreRepository  extends CrudRepository<Store, UUID> {
+  Boolean existsByName(String name);
+}

--- a/src/main/java/run/bemin/api/store/service/StoreService.java
+++ b/src/main/java/run/bemin/api/store/service/StoreService.java
@@ -1,0 +1,34 @@
+package run.bemin.api.store.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import run.bemin.api.category.entity.Category;
+import run.bemin.api.category.exception.CategoryAlreadyExistsByNameException;
+import run.bemin.api.store.dto.StoreDto;
+import run.bemin.api.store.dto.request.CreateStoreRequestDto;
+import run.bemin.api.store.entity.Store;
+import run.bemin.api.store.repository.StoreRepository;
+
+@RequiredArgsConstructor
+@Service
+public class StoreService {
+
+  private final StoreRepository storeRepository;
+
+  public Boolean existsStoreByName(String name) {
+    return storeRepository.existsByName(name);
+  }
+
+  @Transactional
+  public StoreDto createStore(CreateStoreRequestDto requestDto) {
+    Store store = Store.create(
+        requestDto.name(),
+        requestDto.phone(),
+        requestDto.minimumPrice(),
+        requestDto.userEmail());
+
+    Store savedStore = storeRepository.save(store);
+    return StoreDto.fromEntity(savedStore);
+  }
+}


### PR DESCRIPTION
가게 등록 api 까지 구현했습니다. 컨트롤러는 크게 관리자 API, 일반 API 두 개로 구분해서 구현했습니다.
가게 이름은 중복이 가능하기 때문에 검사를 하지 않습니다.

## ⚙️ PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 🔑 Key Changes

-

<br/>

## 🤝🏻 To Reviewers

- #18 

<br/>

