### PR TITLE
가게카테고리 엔티티 구현 및 연관 관계 매핑하기

### DIFF
--- a/src/main/java/run/bemin/api/category/entity/Category.java
+++ b/src/main/java/run/bemin/api/category/entity/Category.java
@@ -1,18 +1,23 @@
 package run.bemin.api.category.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import run.bemin.api.store.entity.StoreCategory;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,8 +32,10 @@ public class Category {
   @Column(name = "name", nullable = false, unique = true)
   private String name;
 
+  @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = false)
+  private final List<StoreCategory> storeCategories = new ArrayList<>();
+
   @Column(name = "is_deleted", nullable = false)
-  @ColumnDefault("true")
   private Boolean isDeleted;
 
   @Column(name = "created_by", updatable = false)

--- a/src/main/java/run/bemin/api/store/entity/Store.java
+++ b/src/main/java/run/bemin/api/store/entity/Store.java
@@ -1,16 +1,19 @@
 package run.bemin.api.store.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -33,6 +36,9 @@ public class Store {
 
   @Column(name = "rating")
   private Float rating;
+
+  @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = false)
+  private final List<StoreCategory> storeCategories = new ArrayList<>();
 
   @Column(name = "is_deleted")
   private Boolean isDeleted;

--- a/src/main/java/run/bemin/api/store/entity/StoreCategory.java
+++ b/src/main/java/run/bemin/api/store/entity/StoreCategory.java
@@ -1,0 +1,83 @@
+package run.bemin.api.store.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import run.bemin.api.category.entity.Category;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class StoreCategory {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "store_id", nullable = false)
+  private Store store;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "category_id", nullable = false)
+  private Category category;
+
+  @Column(name = "is_primary", nullable = false)
+  private Boolean isPrimary;
+
+  @Column(name = "is_deleted", nullable = false)
+  private Boolean isDeleted;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
+
+  @Column(name = "created_by", nullable = false, updatable = false)
+  private String createdBy;
+
+  @Column(name = "updated_by")
+  private String updatedBy;
+
+  @Column(name = "deleted_by")
+  private String deletedBy;
+
+  private StoreCategory(Store store, Category category, Boolean isPrimary, String createdBy) {
+    this.store = store;
+    this.category = category;
+    this.isPrimary = isPrimary != null ? isPrimary : false;
+    this.isDeleted = false;
+    this.createdBy = createdBy;
+    this.createdAt = LocalDateTime.now();
+  }
+
+  public static StoreCategory create(Store store, Category category, Boolean isPrimary, String createdBy) {
+    return new StoreCategory(store, category, isPrimary, createdBy);
+  }
+
+  public void softDelete(String deletedBy) {
+    this.isDeleted = true;
+    this.deletedBy = deletedBy;
+    this.deletedAt = LocalDateTime.now();
+  }
+
+  public void update(String updatedBy, Boolean isPrimary) {
+    this.updatedBy = updatedBy;
+    this.updatedAt = LocalDateTime.now();
+    this.isPrimary = isPrimary != null ? isPrimary : this.isPrimary;
+  }
+}


### PR DESCRIPTION
LAZY(지연 로딩) 전략으로 설정했습니다. 그 이유는, 
- `StoreCategory`를 조회할 때 **`category`는 조회하지 않습니다**
- `getCategory()`를 호출하는 순간 **실제로 DB에서 데이터를 가져옵니다 (프록시 객체)**

따라서, 불필요한 JOIN을 방지하여 성능 최적화하고, 필요할 때만 데이터를 가져와 메모리 절약이 가능합니다. 그리고 **N+1 문제 예방 가능**합니다!

가게, 카테고리 엔티티의 연관 관계 필드의 리스트를 모두 final로 했습니다.불변성을 유지해서 리스트 자체를 재할당하지 않기 위함입니다. 일반적으로 할 일이 없다고 생각합니다...

**`orphanRemoval = false` 설정 이유**

- `orphanRemoval = true`를 사용하면 엔티티가 제거될 때 연관된 `StoreCategory`도 삭제됩니다.
- 소프트 삭제를 사용하므로 **엔티티를 제거하는 것이 아니라 `isDeleted = true`로 변경**해야 합니다.
- 따라서 **`orphanRemoval = false`로 설정하여 JPA가 자동 삭제하지 않도록 해야 합니다**.

정리하자면,

**중간 테이블(`StoreCategory`)도 소프트 삭제(`isDeleted = true` 적용) → 실제 삭제하지 않습니다.**
**`deleted_at`, `deleted_by` 추가하여 삭제 이력 관리 가능합니다**
**JPA의 `@OneToMany`에서 `orphanRemoval = false` 설정하여 자동 삭제 방지합니다**
**`softDelete()` 메서드 추가하여 소프트 삭제 로직 명확하게 구현합니다**
**조회 시 `isDeleted = false` 조건을 추가하여 활성 데이터만 조회합니다**

따라서 **중간 테이블도 소프트 삭제 정책을 따라 유연하게 관리할 수 있습니다...**

## ⚙️ PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 🔑 Key Changes

-

<br/>

## 🤝🏻 To Reviewers

-

<br/>

