### PR TITLE
 카게주소 엔티티 구현하기

### DIFF
--- a/src/main/java/run/bemin/api/store/entity/Store.java
+++ b/src/main/java/run/bemin/api/store/entity/Store.java
@@ -3,10 +3,13 @@ package run.bemin.api.store.entity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -36,6 +39,10 @@ public class Store {
 
   @Column(name = "rating")
   private Float rating;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "store_address_id")
+  private StoreAddress storeAddress;
 
   @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = false)
   private final List<StoreCategory> storeCategories = new ArrayList<>();

--- a/src/main/java/run/bemin/api/store/entity/StoreAddress.java
+++ b/src/main/java/run/bemin/api/store/entity/StoreAddress.java
@@ -1,0 +1,36 @@
+package run.bemin.api.store.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "p_store_address")
+public class StoreAddress {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "store_address_id", unique = true, nullable = false)
+  private UUID id;
+
+  @Column(name = "bcode", nullable = false)
+  private String bcode;
+
+  @Column(name = "detail", nullable = false)
+  private String detail;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "store_id")
+  private Store store;
+}

--- a/src/main/java/run/bemin/api/store/entity/StoreCategory.java
+++ b/src/main/java/run/bemin/api/store/entity/StoreCategory.java
@@ -17,7 +17,7 @@ import run.bemin.api.category.entity.Category;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity
+@Entity(name = "p_store_category")
 public class StoreCategory {
 
   @Id


### PR DESCRIPTION
가게주소 엔티티를 구현합니다. 1:1 관계이며 가게에 종속적인 엔티티이므로 가게 패키지 경로에 존재합니다. 
페치 전략은 모두 LAZY로 설정했는데, 단일 엔티티 조회하는 경우의 여지가 크기 때문에 예상하지 못한 조회가 발생하는 것을 방지합니다.


## ⚙️ PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 🔑 Key Changes

-

<br/>

## 🤝🏻 To Reviewers

- #18 

<br/>

