### PR TITLE
Refactor: #32 가게 - 회원 연관 관계 설정 및 권한 확인하기

### DIFF
--- a/src/main/java/run/bemin/api/store/controller/AdminStoreController.java
+++ b/src/main/java/run/bemin/api/store/controller/AdminStoreController.java
@@ -5,6 +5,8 @@ import static run.bemin.api.store.dto.StoreResponseCode.STORE_FETCHED;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import run.bemin.api.general.response.ApiResponse;
+import run.bemin.api.security.UserDetailsImpl;
 import run.bemin.api.store.dto.StoreDto;
 import run.bemin.api.store.dto.request.CreateStoreRequestDto;
 import run.bemin.api.store.service.StoreService;
@@ -23,6 +26,7 @@ public class AdminStoreController {
 
   private final StoreService storeService;
 
+
   @GetMapping("/{storeName}")
   public ResponseEntity<ApiResponse<Boolean>> existsStoreName(@PathVariable String storeName) {
     Boolean existsStoreByName = storeService.existsStoreByName(storeName);
@@ -32,10 +36,12 @@ public class AdminStoreController {
         .body(ApiResponse.from(STORE_FETCHED.getStatus(), STORE_FETCHED.getMessage(), existsStoreByName));
   }
 
+  @PreAuthorize("not hasRole('CUSTOMER')")
   @PostMapping
   public ResponseEntity<ApiResponse<StoreDto>> createStore(
-      @RequestBody CreateStoreRequestDto requestDto) {
-    StoreDto storeDto = storeService.createStore(requestDto);
+      @RequestBody CreateStoreRequestDto requestDto,
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    StoreDto storeDto = storeService.createStore(requestDto, userDetails);
 
     return ResponseEntity
         .status(STORE_CREATED.getStatus())

--- a/src/main/java/run/bemin/api/store/dto/StoreDto.java
+++ b/src/main/java/run/bemin/api/store/dto/StoreDto.java
@@ -11,6 +11,7 @@ public record StoreDto(
     Integer minimumPrice,
     Float rating,
     Boolean isDeleted,
+    String userEmail,
     String createdBy,
     String updatedBy,
     String deletedBy,
@@ -30,6 +31,7 @@ public record StoreDto(
         store.getCreatedBy(),
         store.getUpdatedBy(),
         store.getDeletedBy(),
+        store.getUserEmail(),
         store.getCreatedAt(),
         store.getUpdatedAt(),
         store.getDeletedAt()

--- a/src/main/java/run/bemin/api/store/entity/Store.java
+++ b/src/main/java/run/bemin/api/store/entity/Store.java
@@ -25,7 +25,7 @@ public class Store {
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
-  @Column(name = "category_id", nullable = false, updatable = false, unique = true)
+  @Column(name = "store_id", nullable = false, updatable = false, unique = true)
   private UUID id;
 
   @Column(name = "name", nullable = false)
@@ -50,6 +50,12 @@ public class Store {
   @Column(name = "is_deleted")
   private Boolean isDeleted;
 
+  @Column(name = "deleted_at", nullable = true)
+  private LocalDateTime deletedAt;
+
+  @Column(name = "user_email", nullable = false)
+  private String userEmail;
+
   @Column(name = "created_by", updatable = false)
   private String createdBy;
 
@@ -65,19 +71,17 @@ public class Store {
   @Column(name = "updated_at", nullable = true)
   private LocalDateTime updatedAt;
 
-  @Column(name = "deleted_at", nullable = true)
-  private LocalDateTime deletedAt;
-
-  private Store(String name, String phone, Integer minimumPrice, String createdBy) {
+  private Store(String name, String phone, Integer minimumPrice, String createdBy, String userEmail) {
     this.name = name;
     this.phone = phone;
     this.minimumPrice = minimumPrice;
     this.isDeleted = false;
     this.createdBy = createdBy;
+    this.userEmail = userEmail;
     this.createdAt = LocalDateTime.now();
   }
 
-  public static Store create(String name, String phone, Integer minimumPrice, String createdBy) {
-    return new Store(name, phone, minimumPrice, createdBy);
+  public static Store create(String name, String phone, Integer minimumPrice, String createdBy, String userEmail) {
+    return new Store(name, phone, minimumPrice, createdBy, userEmail);
   }
 }

--- a/src/main/java/run/bemin/api/store/entity/StoreAddress.java
+++ b/src/main/java/run/bemin/api/store/entity/StoreAddress.java
@@ -24,8 +24,17 @@ public class StoreAddress {
   @Column(name = "store_address_id", unique = true, nullable = false)
   private UUID id;
 
+  @Column(name = "zone_code")
+  private String zoneCode; // 국가기초구역번호
+
   @Column(name = "bcode", nullable = false)
-  private String bcode;
+  private String bcode; // 법정동/법정리 코드
+
+  @Column(name = "jibun_address", nullable = false)
+  private String jibunAddress; // 지번 주소
+
+  @Column(name = "road_address", nullable = false)
+  private String roadAddress; // 도로명 주소
 
   @Column(name = "detail", nullable = false)
   private String detail;

--- a/src/main/java/run/bemin/api/store/service/StoreService.java
+++ b/src/main/java/run/bemin/api/store/service/StoreService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import run.bemin.api.category.entity.Category;
 import run.bemin.api.category.exception.CategoryAlreadyExistsByNameException;
+import run.bemin.api.security.UserDetailsImpl;
 import run.bemin.api.store.dto.StoreDto;
 import run.bemin.api.store.dto.request.CreateStoreRequestDto;
 import run.bemin.api.store.entity.Store;
@@ -21,12 +22,13 @@ public class StoreService {
   }
 
   @Transactional
-  public StoreDto createStore(CreateStoreRequestDto requestDto) {
+  public StoreDto createStore(CreateStoreRequestDto requestDto, UserDetailsImpl userDetails) {
     Store store = Store.create(
         requestDto.name(),
         requestDto.phone(),
         requestDto.minimumPrice(),
-        requestDto.userEmail());
+        requestDto.userEmail(),
+        userDetails.getUsername());
 
     Store savedStore = storeRepository.save(store);
     return StoreDto.fromEntity(savedStore);


### PR DESCRIPTION
가게 - 회원은 1:1 관계이다.
단, 모든 회원이 가게를 보유하지 않으며 회원의 기본키는 이메일이다.

이 두 조건에 가장 적절한 방법은 연관 관계 매핑을 하지 않고, 가게 엔티티  안에 이메일 필드를 생성하고 관리하는 방법이 적절하다고 생각했습니다. 연관 관계로 인해 회원 엔티티에서 불필요한 조인 발생 및 컬럼이 추가되는 것을 방지할 수 있으며 null 데이터를 불필요하게 생성하지 않을 수 있습니다.

## ⚙️ PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 🔑 Key Changes

-

<br/>

## 🤝🏻 To Reviewers

- #32 

<br/>

