### PR TITLE
Refactor: #32 감사 기능 수정하기

### DIFF
--- a/src/main/java/run/bemin/BeminApplication.java
+++ b/src/main/java/run/bemin/BeminApplication.java
@@ -6,7 +6,6 @@ import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @EnableSpringDataWebSupport(pageSerializationMode = PageSerializationMode.VIA_DTO)
 @SpringBootApplication
 public class BeminApplication {

--- a/src/main/java/run/bemin/api/config/AuditingConfig.java
+++ b/src/main/java/run/bemin/api/config/AuditingConfig.java
@@ -1,0 +1,17 @@
+package run.bemin.api.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.domain.AuditorAware;
+import run.bemin.api.general.auditing.AuditorAwareImpl;
+
+@Configuration
+@EnableJpaAuditing(auditorAwareRef = "auditorAware")
+public class AuditingConfig {
+
+  @Bean
+  public AuditorAware<String> auditorAware() {
+    return new AuditorAwareImpl();
+  }
+}

--- a/src/main/java/run/bemin/api/general/auditing/AuditableEntity.java
+++ b/src/main/java/run/bemin/api/general/auditing/AuditableEntity.java
@@ -25,11 +25,11 @@ public class AuditableEntity {
   private String createdBy;
 
   @LastModifiedDate
-  @Column(updatable = false, name = "update_at")
+  @Column(updatable = false, name = "updated_at")
   private LocalDateTime updatedAt;
 
   @LastModifiedBy
-  @Column(updatable = false, name = "update_by")
-  private String updateBy;
+  @Column(updatable = false, name = "updated_by")
+  private String updatedBy;
 
 }

--- a/src/main/java/run/bemin/api/general/auditing/AuditorAwareImpl.java
+++ b/src/main/java/run/bemin/api/general/auditing/AuditorAwareImpl.java
@@ -1,7 +1,6 @@
 package run.bemin.api.general.auditing;
 
 import java.util.Optional;
-import jdk.jshell.spi.ExecutionControl.UserException;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -14,12 +13,11 @@ public class AuditorAwareImpl implements AuditorAware<String> {
   @Override
   public Optional<String> getCurrentAuditor() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    // 권한 설정이 완성되면 주석 해제 하겠습니다.
-    //validateAuthentication(authentication);
+    validateAuthentication(authentication);
     return Optional.of(((UserDetailsImpl) authentication.getPrincipal()).getUsername());
   }
 
-  private void validateAuthentication(Authentication authentication) throws UserException {
+  private void validateAuthentication(Authentication authentication) {
     if (authentication == null || !authentication.isAuthenticated()) {
       throw new AuthAccessDeniedException(ErrorCode.AUTH_ACCESS_DENIED.getMessage());
     }


### PR DESCRIPTION
1. 애플리케이션 부트 클래스 -> AuditingConfig에서 관리
2. update -> updated 수정

@EnableJpaAuditing는 감사 기능을 활성화하지만, AuditorAware를 구현한 빈이 스프링 컨텍스트에 등록되어 있어야 실제 감사 값(생성자, 수정자 등)이 주입되도록 AuditingConfg를 생성했습니다.

현재 부트 클래스에 @EnableJpaAuditing만 붙여두면, AuditorAware 빈이 없기 때문에 감사 관련 필드가 NULL로 남을 수 있는 여지가 있습니다.

따라서 아래와 같이 별도의 설정 클래스를 만들어 AuditorAware 빈을 등록하거나, AuditorAwareImpl 클래스에 @Component 어노테이션을 추가했습니다.


![image](https://github.com/user-attachments/assets/e9c33f49-76cc-41eb-b805-9927c58b5266)


## ⚙️ PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 🔑 Key Changes

-

<br/>

## 🤝🏻 To Reviewers

- #32 

<br/>

