### PR TITLE
가게 수정 API 구현 및 가게, 카테고리 audit 적용하기

### DIFF
--- a/src/main/java/run/bemin/api/category/controller/AdminCategoryController.java
+++ b/src/main/java/run/bemin/api/category/controller/AdminCategoryController.java
@@ -34,7 +34,6 @@ public class AdminCategoryController {
   private final CategoryService categoryService;
 
   @PreAuthorize("hasAnyRole(" +
-      "T(run.bemin.api.user.entity.UserRoleEnum).OWNER.getAuthority(), " +
       "T(run.bemin.api.user.entity.UserRoleEnum).MANAGER.getAuthority(), " +
       "T(run.bemin.api.user.entity.UserRoleEnum).MASTER.getAuthority())")
   @PostMapping
@@ -74,9 +73,8 @@ public class AdminCategoryController {
         ApiResponse.from(CATEGORIES_FETCHED.getStatus(), CATEGORIES_FETCHED.getMessage(), categories));
   }
 
+
   @PreAuthorize("hasAnyRole(" +
-      "T(run.bemin.api.user.entity.UserRoleEnum).CUSTOMER.getAuthority(), " +
-      "T(run.bemin.api.user.entity.UserRoleEnum).OWNER.getAuthority(), " +
       "T(run.bemin.api.user.entity.UserRoleEnum).MANAGER.getAuthority(), " +
       "T(run.bemin.api.user.entity.UserRoleEnum).MASTER.getAuthority())")
   @PatchMapping

--- a/src/main/java/run/bemin/api/category/controller/CategoryController.java
+++ b/src/main/java/run/bemin/api/category/controller/CategoryController.java
@@ -39,6 +39,4 @@ public class CategoryController {
     return ResponseEntity.ok(
         ApiResponse.from(CATEGORIES_FETCHED.getStatus(), CATEGORIES_FETCHED.getMessage(), categories));
   }
-
-
 }

--- a/src/main/java/run/bemin/api/category/entity/Category.java
+++ b/src/main/java/run/bemin/api/category/entity/Category.java
@@ -7,8 +7,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,13 +14,13 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
+import run.bemin.api.general.auditing.AuditableEntity;
 import run.bemin.api.store.entity.StoreCategory;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "p_category")
-public class Category {
+public class Category extends AuditableEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
@@ -36,74 +34,32 @@ public class Category {
   private final List<StoreCategory> storeCategories = new ArrayList<>();
 
   @Column(name = "is_deleted", nullable = false)
-  private Boolean isDeleted;
+  private Boolean isDeleted = false;
 
-  @Column(name = "created_by", updatable = false)
-  private String createdBy;
-
-  @Column(name = "updated_by", nullable = true)
-  private String updatedBy;
-
-  @Column(name = "deleted_by", nullable = true)
+  @Column(name = "deleted_by")
   private String deletedBy;
 
-  @Column(name = "created_at", nullable = false)
-  private LocalDateTime createdAt;
-
-  @Column(name = "updated_at", nullable = true)
-  private LocalDateTime updatedAt;
-
-  @Column(name = "deleted_at", nullable = true)
+  @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 
-  private Category(String name, Boolean isDeleted, String createdBy, String updatedBy, String deletedBy,
-                   LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+  private Category(String name) {
     this.name = name;
-    this.isDeleted = isDeleted;
-    this.createdBy = createdBy;
-    this.updatedBy = updatedBy;
-    this.deletedBy = deletedBy;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
-    this.deletedAt = deletedAt;
   }
 
   public static Category create(String name, String createdBy) {
-    return new Category(
-        name,
-        false,
-        createdBy,
-        null,
-        null,
-        LocalDateTime.now(),
-        null,
-        null);
+    return new Category(name);
   }
 
   public void update(String updatedBy, String name, Boolean isDeleted) {
-    this.updatedBy = updatedBy;
     this.name = name;
-    this.isDeleted = isDeleted != null ? isDeleted : this.isDeleted;
-    this.updatedAt = LocalDateTime.now();
+    if (isDeleted != null) {
+      this.isDeleted = isDeleted;
+    }
   }
 
   public void softDelete(String deletedBy) {
-    this.deletedBy = deletedBy;
     this.isDeleted = true;
+    this.deletedBy = deletedBy;
     this.deletedAt = LocalDateTime.now();
-    this.updatedAt = LocalDateTime.now();
-    this.updatedBy = deletedBy;
   }
-
-  @PrePersist
-  protected void onCreate() {
-    this.createdAt = LocalDateTime.now();
-  }
-
-  @PreUpdate
-  protected void onUpdate() {
-    this.updatedAt = LocalDateTime.now();
-  }
-
-
 }

--- a/src/main/java/run/bemin/api/store/controller/AdminStoreController.java
+++ b/src/main/java/run/bemin/api/store/controller/AdminStoreController.java
@@ -2,7 +2,10 @@ package run.bemin.api.store.controller;
 
 import static run.bemin.api.store.dto.StoreResponseCode.STORE_CREATED;
 import static run.bemin.api.store.dto.StoreResponseCode.STORE_FETCHED;
+import static run.bemin.api.store.dto.StoreResponseCode.STORE_UPDATED;
 
+import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -10,6 +13,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,6 +21,7 @@ import run.bemin.api.general.response.ApiResponse;
 import run.bemin.api.security.UserDetailsImpl;
 import run.bemin.api.store.dto.StoreDto;
 import run.bemin.api.store.dto.request.CreateStoreRequestDto;
+import run.bemin.api.store.dto.request.UpdateAllStoreRequestDto;
 import run.bemin.api.store.service.StoreService;
 
 @RequiredArgsConstructor
@@ -27,6 +32,7 @@ public class AdminStoreController {
   private final StoreService storeService;
 
 
+  @PreAuthorize("not hasRole('CUSTOMER')")
   @GetMapping("/{storeName}")
   public ResponseEntity<ApiResponse<Boolean>> existsStoreName(@PathVariable String storeName) {
     Boolean existsStoreByName = storeService.existsStoreByName(storeName);
@@ -48,5 +54,18 @@ public class AdminStoreController {
         .body(ApiResponse.from(STORE_CREATED.getStatus(), STORE_CREATED.getMessage(), storeDto));
   }
 
+
+  @PutMapping("/{storeId}")
+  public ResponseEntity<ApiResponse<StoreDto>> updateAllStore(
+      @PathVariable("storeId") UUID storeId,
+      @RequestBody @Valid UpdateAllStoreRequestDto requestDto,
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+    StoreDto storeDto = storeService.updateAllStore(storeId, requestDto, userDetails);
+
+    return ResponseEntity
+        .status(STORE_UPDATED.getStatus())
+        .body(ApiResponse.from(STORE_UPDATED.getStatus(), STORE_UPDATED.getMessage(), storeDto));
+  }
 
 }

--- a/src/main/java/run/bemin/api/store/dto/StoreDto.java
+++ b/src/main/java/run/bemin/api/store/dto/StoreDto.java
@@ -12,11 +12,11 @@ public record StoreDto(
     Float rating,
     Boolean isDeleted,
     String userEmail,
-//    String createdBy,
-//    String updatedBy,
+    String createdBy,
+    String updatedBy,
     String deletedBy,
-//    LocalDateTime createdAt,
-//    LocalDateTime updatedAt,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
     LocalDateTime deletedAt
 ) {
 
@@ -28,12 +28,12 @@ public record StoreDto(
         store.getMinimumPrice(),
         store.getRating(),
         store.isDeleted(),
-        store.getUserEmail(),  // 순서 수정
-//        store.getCreatedBy(),
-//        store.getUpdatedBy(),
+        store.getUserEmail(),
+        store.getCreatedBy(),
+        store.getUpdatedBy(),
         store.getDeletedBy(),
-//        store.getCreatedAt(),
-//        store.getUpdatedAt(),
+        store.getCreatedAt(),
+        store.getUpdatedAt(),
         store.getDeletedAt()
     );
   }

--- a/src/main/java/run/bemin/api/store/dto/request/UpdateAllStoreRequestDto.java
+++ b/src/main/java/run/bemin/api/store/dto/request/UpdateAllStoreRequestDto.java
@@ -1,0 +1,51 @@
+package run.bemin.api.store.dto.request;
+
+import static run.bemin.api.store.dto.StoreValidationMessages.*;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.UUID;
+
+public record UpdateAllStoreRequestDto(
+    @NotBlank(message = STORE_NAME_BLANK)
+    @Pattern(regexp = "^[a-zA-Z가-힣0-9\\s]{1,36}$", message = STORE_NAME_INVALID)
+    String name,
+
+    @NotBlank(message = STORE_PHONE_BLANK)
+    @Pattern(regexp = "^\\d{10,11}$", message = STORE_PHONE_INVALID)
+    String phone,
+
+    @Min(value = 0, message = STORE_MINIMUM_PRICE_INVALID)
+    Integer minimumPrice,
+
+    Boolean isActive,
+
+    @NotBlank(message = USER_EMAIL_BLANK)
+    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$", message = USER_EMAIL_INVALID)
+    String userEmail,
+
+    @NotBlank(message = STORE_ZONE_CODE_BLANK)
+    @Pattern(regexp = "^\\d{5}$", message = STORE_ZONE_CODE_INVALID)
+    String zoneCode,
+
+    @NotBlank(message = STORE_BCODE_BLANK)
+    @Pattern(regexp = "^\\d{10}$", message = STORE_BCODE_INVALID)
+    String bcode,
+
+    @NotBlank(message = STORE_JIBUN_ADDRESS_BLANK)
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9\\s\\-,]{7,84}$", message = STORE_JIBUN_ADDRESS_INVALID)
+    String jibunAddress,
+
+    @NotBlank(message = STORE_ROAD_ADDRESS_BLANK)
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9\\s\\-,]{7,84}$", message = STORE_ROAD_ADDRESS_INVALID)
+    String roadAddress,
+
+    @NotBlank(message = STORE_ADDRESS_DETAIL_BLACK)
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9\\s\\-,]{1,84}$", message = STORE_ADDRESS_DETAIL_INVALID)
+    String detail,
+
+    @Size(max = 4, message = "최대 4개의 카테고리만 선택할 수 있습니다.")
+    List<UUID> categoryIds
+) {}

--- a/src/main/java/run/bemin/api/store/entity/StoreAddress.java
+++ b/src/main/java/run/bemin/api/store/entity/StoreAddress.java
@@ -13,12 +13,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import run.bemin.api.general.auditing.AuditableEntity;
 
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "p_store_address")
-public class StoreAddress {
+public class StoreAddress extends AuditableEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
@@ -58,5 +59,13 @@ public class StoreAddress {
   // Store와의 양방향 연관관계 설정용 메서드
   public void setStore(Store store) {
     this.store = store;
+  }
+
+  public void update(String zoneCode, String bcode, String jibunAddress, String roadAddress, String detail) {
+    this.zoneCode = zoneCode;
+    this.bcode = bcode;
+    this.jibunAddress = jibunAddress;
+    this.roadAddress = roadAddress;
+    this.detail = detail;
   }
 }

--- a/src/main/java/run/bemin/api/store/entity/StoreCategory.java
+++ b/src/main/java/run/bemin/api/store/entity/StoreCategory.java
@@ -14,11 +14,12 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import run.bemin.api.category.entity.Category;
+import run.bemin.api.general.auditing.AuditableEntity;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "p_store_category")
-public class StoreCategory {
+public class StoreCategory extends AuditableEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
@@ -36,22 +37,10 @@ public class StoreCategory {
   private Boolean isPrimary;
 
   @Column(name = "is_deleted", nullable = false)
-  private Boolean isDeleted;
-
-  @Column(name = "created_at", nullable = false, updatable = false)
-  private LocalDateTime createdAt;
-
-  @Column(name = "updated_at")
-  private LocalDateTime updatedAt;
+  private Boolean isDeleted = false;
 
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
-
-  @Column(name = "created_by", nullable = false, updatable = false)
-  private String createdBy;
-
-  @Column(name = "updated_by")
-  private String updatedBy;
 
   @Column(name = "deleted_by")
   private String deletedBy;
@@ -60,9 +49,6 @@ public class StoreCategory {
     this.store = store;
     this.category = category;
     this.isPrimary = isPrimary != null ? isPrimary : false;
-    this.isDeleted = false;
-    this.createdBy = createdBy;
-    this.createdAt = LocalDateTime.now();
   }
 
   public static StoreCategory create(Store store, Category category, Boolean isPrimary, String createdBy) {
@@ -76,8 +62,14 @@ public class StoreCategory {
   }
 
   public void update(String updatedBy, Boolean isPrimary) {
-    this.updatedBy = updatedBy;
-    this.updatedAt = LocalDateTime.now();
     this.isPrimary = isPrimary != null ? isPrimary : this.isPrimary;
   }
+
+  public void restore(String updatedBy, Boolean isPrimary) {
+    this.isDeleted = false;
+    this.deletedBy = null;
+    this.deletedAt = null;
+    update(updatedBy, isPrimary);
+  }
+
 }

--- a/src/main/java/run/bemin/api/store/service/StoreService.java
+++ b/src/main/java/run/bemin/api/store/service/StoreService.java
@@ -1,22 +1,29 @@
 package run.bemin.api.store.service;
 
+import static run.bemin.api.general.exception.ErrorCode.CATEGORY_NOT_FOUND;
+
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import run.bemin.api.category.entity.Category;
+import run.bemin.api.category.exception.CategoryNotFoundException;
 import run.bemin.api.category.repository.CategoryRepository;
 import run.bemin.api.security.UserDetailsImpl;
 import run.bemin.api.store.dto.StoreDto;
 import run.bemin.api.store.dto.request.CreateStoreRequestDto;
+import run.bemin.api.store.dto.request.UpdateAllStoreRequestDto;
 import run.bemin.api.store.entity.Store;
 import run.bemin.api.store.entity.StoreAddress;
+import run.bemin.api.store.exception.CategoryCountExceededException;
 import run.bemin.api.store.repository.StoreRepository;
-
 
 @RequiredArgsConstructor
 @Service
 public class StoreService {
+
+  private static final int MAX_CATEGORY_COUNT = 4;
 
   private final StoreRepository storeRepository;
   private final CategoryRepository categoryRepository;
@@ -25,17 +32,22 @@ public class StoreService {
     return storeRepository.existsByName(name);
   }
 
+  // 카테고리 수 검증 및 존재 여부 검증을 함께 수행
+  private List<Category> validateAndFetchCategories(List<UUID> categoryIds) {
+    if (categoryIds.size() > MAX_CATEGORY_COUNT) {
+      throw new CategoryCountExceededException("최대 " + MAX_CATEGORY_COUNT + "개의 카테고리만 선택할 수 있습니다.");
+    }
+    List<Category> categories = categoryRepository.findAllByIdIn(categoryIds);
+    if (categories.size() != categoryIds.size()) {
+      throw new CategoryNotFoundException(CATEGORY_NOT_FOUND.getMessage());
+    }
+    return categories;
+  }
+
   @Transactional
   public StoreDto createStore(CreateStoreRequestDto requestDto, UserDetailsImpl userDetails) {
-    if (requestDto.categoryIds().size() > 4) { // (추가 검증이 필요하면) 카테고리 선택 개수 검증
-      throw new IllegalArgumentException("최대 4개의 카테고리만 선택할 수 있습니다.");
-    }
-
-    // 카테고리 조회
-    List<Category> categories = categoryRepository.findAllByIdIn(requestDto.categoryIds());
-    if (categories.size() != requestDto.categoryIds().size()) {
-      throw new IllegalArgumentException("존재하지 않는 카테고리가 있습니다.");
-    }
+    // 카테고리 검증 및 조회
+    List<Category> categories = validateAndFetchCategories(requestDto.categoryIds());
 
     // StoreAddress 생성
     StoreAddress storeAddress = StoreAddress.builder()
@@ -46,7 +58,7 @@ public class StoreService {
         .detail(requestDto.detail())
         .build();
 
-    // Store 생성 (생성일은 현재 시간 사용)
+    // Store 생성
     Store store = Store.create(
         requestDto.name(),
         requestDto.phone(),
@@ -54,18 +66,51 @@ public class StoreService {
         true, // isActive 기본값
         storeAddress,
         requestDto.userEmail()
-//        userDetails.getUsername(),
-//        LocalDateTime.now()
     );
 
-    // 양방향 연관관계 설정: StoreAddress 에 Store 할당
+    // 양방향 연관관계 설정: StoreAddress에 Store 할당
     storeAddress.setStore(store);
 
-    // Store 와 여러 카테고리 연결 (각 카테고리 등록 시 createdBy 정보를 함께 전달)
+    // 카테고리 연결 (각 카테고리 등록 시 createdBy 정보를 전달)
     categories.forEach(category -> store.addCategory(category, userDetails.getUsername()));
 
     // Store 저장 (Cascade 옵션 덕분에 주소도 함께 저장됨)
     Store savedStore = storeRepository.save(store);
     return StoreDto.fromEntity(savedStore);
+  }
+
+  @Transactional
+  public StoreDto updateAllStore(UUID storeId, UpdateAllStoreRequestDto requestDto, UserDetailsImpl userDetails) {
+    // 1. 가게 조회
+    Store store = storeRepository.findById(storeId)
+        .orElseThrow(() -> new IllegalArgumentException("해당 가게가 존재하지 않습니다."));
+
+    // 2. 카테고리 검증 및 조회
+    List<Category> categories = validateAndFetchCategories(requestDto.categoryIds());
+
+    // 3. 기본 가게 정보 업데이트
+    store.update(
+        requestDto.name(),
+        requestDto.phone(),
+        requestDto.minimumPrice(),
+        requestDto.isActive(),
+        requestDto.userEmail()
+    );
+
+    // 4. 가게 주소 업데이트 (가게 주소가 null이 아니라고 가정)
+    store.getStoreAddress().update(
+        requestDto.zoneCode(),
+        requestDto.bcode(),
+        requestDto.jibunAddress(),
+        requestDto.roadAddress(),
+        requestDto.detail()
+    );
+
+    // 5. 카테고리 업데이트 (기존 목록 삭제 후 재설정)
+    store.updateCategories(categories, userDetails.getUsername());
+
+    // 6. 업데이트된 가게 저장
+    Store updatedStore = storeRepository.save(store);
+    return StoreDto.fromEntity(updatedStore);
   }
 }


### PR DESCRIPTION
### 가게

가게 정보를 수정하기 위해서는 가게, 가게주소, 가게카테고리를 고려해야 합니다.

- 기존 연결 중 새 목록에 없는 항목에 대해 소프트 삭제(soft delete)를 수행
- 새 목록에 있는 항목에 대해 기존 연결이 있으면 업데이트(또는 복원), 없으면 신규로 추가

1. 새 목록을 빠르게 조회하기 위한 Map 생성
2. 기존 연결에서 새 목록에 없는 항목을 소프트 삭제
3. 새 목록을 순회하며 기존 연결 업데이트 또는 신규 추가

새 목록 준비:
새 카테고리 목록을 ID 기준으로 빠르게 확인할 수 있도록 Map으로 변환합니다.

기존 연결 삭제 처리:
현재 저장된 카테고리 연결 중에서 새 목록에 없는 항목은 소프트 삭제 처리합니다.

새 목록 반영:
새 목록을 순회하면서,

기존에 연결되어 있던 항목이면 (삭제 상태이면 복원, 활성 상태이면 업데이트)
새로 연결이 필요한 항목이면 신규 생성하여 추가합니다.
또한, 새 목록의 첫 번째 항목은 primary로 지정됩니다.

이 과정을 통해 엔티티의 카테고리 연결 정보가 새 목록과 정확하게 동기화되며, 불필요한 데이터는 소프트 삭제되고 필요한 연결은 업데이트 또는 신규 추가됩니다.

가게주소, 가게카테고리에는 Audit 적용과 필요한 update 메서드를 구현했습니다.

## ⚙️ PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 🔑 Key Changes

-

<br/>

## 🤝🏻 To Reviewers

- #54 

<br/>

