### PR TITLE
Fix: User - UserAddress 엔티티간 순환 참조 및 lazy 프록시 직렬화 오류 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,13 +52,17 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-    
+
     // S3 의존성 추가 - 김형주 2/19
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.0'
 
     // 이미지 최적화 - 김형주 2/20
     implementation("com.sksamuel.scrimage:scrimage-core:4.1.3")
     implementation("com.sksamuel.scrimage:scrimage-webp:4.1.3")
+
+    // Hibernate6 모듈 추가 (Hibernate 6 lazy 프록시 직렬화 오류 방지) - 공희진 2/22
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate6:2.18.2'
+
 
 }
 

--- a/src/main/java/run/bemin/api/config/JacksonConfig.java
+++ b/src/main/java/run/bemin/api/config/JacksonConfig.java
@@ -1,0 +1,17 @@
+package run.bemin.api.config;
+
+import com.fasterxml.jackson.datatype.hibernate6.Hibernate6Module;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+  @Bean
+  public Hibernate6Module hibernate6Module() {
+    Hibernate6Module module = new Hibernate6Module();
+    // 필요에 따라 lazy 로딩된 속성을 직렬화하지 않도록 설정
+    module.disable(Hibernate6Module.Feature.FORCE_LAZY_LOADING);
+    return module;
+  }
+}

--- a/src/main/java/run/bemin/api/user/entity/User.java
+++ b/src/main/java/run/bemin/api/user/entity/User.java
@@ -1,6 +1,6 @@
 package run.bemin.api.user.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -63,7 +63,8 @@ public class User extends AuditableEntity {
 
   // 주소 함께 저장 + 주소 함께 삭제
   // 현재클래스To매핑클래스
-  @JsonIgnore
+  // 양방향 관계 관리: User가 부모, 자식인 UserAddress는 역참조하도록 함.
+  @JsonManagedReference // 직렬화 시 userAddressList는 포함됨
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = false)
   private final List<UserAddress> userAddressList = new ArrayList<>();
 

--- a/src/main/java/run/bemin/api/user/entity/UserAddress.java
+++ b/src/main/java/run/bemin/api/user/entity/UserAddress.java
@@ -1,5 +1,6 @@
 package run.bemin.api.user.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -44,8 +45,9 @@ public class UserAddress extends AuditableEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_email")
+  @JsonBackReference // User의 userAddressList에 대한 역참조를 무시
   private User user;
-  
+
   @Column(name = "is_deleted", nullable = false)
   private Boolean isDeleted = false;
 


### PR DESCRIPTION
## ⚙️ PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 🔑 Key Changes
- User 엔티티의 기존 @JsonIgnore를 제거하고, userAddressList에 @JsonManagedReference를 적용하여 양방향 순환 참조 관리
- UserAddress 엔티티의 user 필드에 @JsonBackReference를 추가하여, UserAddress 직렬화 시 User 정보의 재직렬화를 방지
- Hibernate의 lazy 로딩 프록시(ByteBuddyInterceptor) 직렬화 오류 해결을 위해 jackson-datatype-hibernate6 의존성 추가 및 JacksonConfig에 HibernateModule 등록
- User와 UserAddress 간의 순환 참조 문제와 lazy 프록시 관련 직렬화 오류가 모두 해결되었습니다.

<br/>

## 🤝🏻 To Reviewers

-

<br/>

