### PR TITLE
Fix: #102 가게 검색 로직 수정하기

### DIFF
--- a/src/main/java/run/bemin/api/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/run/bemin/api/store/repository/StoreRepositoryImpl.java
@@ -31,48 +31,63 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
     QStoreCategory storeCategory = QStoreCategory.storeCategory;
     QCategory category = QCategory.category;
 
-    // BooleanBuilder 를 통해 조건을 동적으로 구성
-    BooleanBuilder builder = new BooleanBuilder();
+    boolean hasCategory = (categoryName != null && !categoryName.trim().isEmpty());
+    boolean hasStoreName = (storeName != null && !storeName.trim().isEmpty());
 
-    // 가게 조건: 삭제된 가게 제외
-    builder.and(store.isDeleted.eq(false));
-
-    // 카테고리 조건: categoryName 이 입력되었으면 해당 카테고리 이름과 정확히 일치하는 조건 추가
-    if (categoryName != null && !categoryName.isEmpty()) {
-      builder.and(category.name.eq(categoryName));
+    // [사전 체크] 입력된 카테고리명이 Category 테이블에 존재하는지 확인
+    if (hasCategory) {
+      long categoryExistCount = queryFactory
+          .selectFrom(category)
+          .where(category.name.eq(categoryName))
+          .fetchCount();
+      if (categoryExistCount == 0) {
+        // 요청된 카테고리가 DB에 전혀 없으면 빈 결과 반환
+        return new PageImpl<>(List.of(), pageable, 0);
+      }
     }
 
-    // 지점 이름 조건: storeName 이 입력되었으면 지점 이름에 해당 키워드가 포함되는 조건 추가 (대소문자 무시)
-    if (storeName != null && !storeName.isEmpty()) {
+    // 동적 조건 구성
+    BooleanBuilder builder = new BooleanBuilder();
+    // 삭제되지 않은 가게만 조회
+    builder.and(store.isDeleted.eq(false));
+
+    if (hasCategory) {
+      // storeCategory 와 category 엔티티를 이용해서,
+      // 가게가 해당 카테고리(ex: "한식")와 연결되어 있고, 해당 연결(StoreCategory)이 삭제되지 않았어야 함
+      builder.and(storeCategory.isDeleted.eq(false))
+          .and(category.name.eq(categoryName));
+    }
+
+    if (hasStoreName) {
+      // 가게 이름에 storeName 키워드가 포함되어야 함 (대소문자 무시)
       builder.and(store.name.containsIgnoreCase(storeName));
     }
 
-    // 기본 QueryDSL 쿼리 구성 (중복 제거를 위해 distinct 사용)
+    // join 처리: 카테고리 조건을 위해 StoreCategory와 Category 엔티티와 조인
     JPAQuery<Store> query = queryFactory.selectFrom(store)
-        .distinct()
-        // Store 와 연관된 StoreCategory, Category 엔티티를 조인
+        .distinct()  // 동일 가게가 여러 카테고리로 인해 중복되지 않도록
         .leftJoin(store.storeCategories, storeCategory)
         .leftJoin(storeCategory.category, category)
         .where(builder);
 
-    // 전체 개수를 구하기 위한 카운트 쿼리 생성
-    // (정렬 조건 등은 카운트에 영향을 주지 않도록 별도 처리)
+    // 전체 개수 조회
     long total = query.fetchCount();
 
     // 페이징 적용: offset, limit
     query.offset(pageable.getOffset())
         .limit(pageable.getPageSize());
 
+    // 정렬 조건 적용 (Pageable의 정렬 조건 사용)
     for (Sort.Order order : pageable.getSort()) {
-      // "store" 엔티티에 대해 동적으로 정렬 조건 지정
       PathBuilder<Store> path = new PathBuilder<>(Store.class, "store");
       query.orderBy(new OrderSpecifier<>(
           order.isAscending() ? Order.ASC : Order.DESC,
           path.get(order.getProperty(), Comparable.class)
       ));
     }
-    List<Store> stores = query.fetch();
 
+    List<Store> stores = query.fetch();
     return new PageImpl<>(stores, pageable, total);
   }
+
 }


### PR DESCRIPTION
querydsl 로 구현한 가게 검색 기능에서 원하는 것은 카테고리별, 가게 이름별로 검색할 수 있도록 지원하는 것이다.

1. 카테고리 + 가게 이름 모두 검색에 포함되는 경우 예를 들어, "한식" 카테고리에 포함되며 "순대" 키워드가 가게 이름에 포함되는 가게를 검색 후 응답(카테고리 AND 가게 이름)

http://localhost:19010/api/v1/stores/search?categoryName=한식&storeName=순대&page=0&size=10 즉, "순대"라는 가게명을 갖는 가게가 존재하더라도, "한식" 카테고리에 포함되어 있지 않으면 응답하지 않는다.

2. 카테고리만 검색에 포함되는 경우 예를 들어, "한식" 카테고리에 포함된 모든 가게를 검색 후 응답

http://localhost:19010/api/v1/stores/search?categoryName=한식&page=0&size=10
3. 가게 이름만 검색에 포함되는 경우 예를 들어, "순대" 키워드가 가게 이름에 포함되는 가게를 검색 후 응답

http://localhost:19010/api/v1/stores/search?&storeName=순대&page=0&size=10

## ⚙️ PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 🔑 Key Changes

-

<br/>

## 🤝🏻 To Reviewers

-

<br/>

