### PR TITLE
Fix: 메시지 큐를 사용해 비동기로 각 가게의 평점 계산하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,8 @@ dependencies {
     // Hibernate6 모듈 추가 (Hibernate 6 lazy 프록시 직렬화 오류 방지) - 공희진 2/22
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate6:2.18.2'
 
-
+    // RabbitMQ를 사용하기 위한 Spring AMQP
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
 }
 
 tasks.named('test') {

--- a/src/main/java/run/bemin/api/general/auditing/AuditorAwareImpl.java
+++ b/src/main/java/run/bemin/api/general/auditing/AuditorAwareImpl.java
@@ -4,25 +4,30 @@ import java.util.Optional;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import run.bemin.api.auth.exception.AuthAccessDeniedException;
 import run.bemin.api.general.exception.ErrorCode;
 import run.bemin.api.security.UserDetailsImpl;
 
+@Component
 public class AuditorAwareImpl implements AuditorAware<String> {
 
   @Override
   public Optional<String> getCurrentAuditor() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    validateAuthentication(authentication);
+
+    if (authentication == null || !authentication.isAuthenticated()) {
+      // 인증 정보가 없는 경우, 기본값 또는 null을 반환
+      // RabbitMQ 로 Store 갱신하려고 할 때, 인증 정보가 없을 경우 에러남
+      // 그래서 기본 SYSTEM 으로 설정해야 합니다
+      return Optional.of("SYSTEM");
+    }
 
     Object principal = authentication.getPrincipal();
     if (principal instanceof UserDetailsImpl) {
       return Optional.of(((UserDetailsImpl) principal).getUsername());
     } else if (principal instanceof String) {
-      // 예를 들어, 익명 사용자일 경우 Optional.empty()를 반환하거나 기본값을 줄 수 있습니다.
-      // 회원 가입하면, 스프링 시큐리티 세션 안에 저장된 회원 정보가 없습니다! 그래서 Optional 타입으로 null 처리하고,
-      // created_by 컬럼에 null 이 저장됩니다.
-      return Optional.empty();
+      return Optional.of((String) principal);
     }
 
     return Optional.empty();
@@ -33,6 +38,4 @@ public class AuditorAwareImpl implements AuditorAware<String> {
       throw new AuthAccessDeniedException(ErrorCode.AUTH_ACCESS_DENIED.getMessage());
     }
   }
-
-
 }

--- a/src/main/java/run/bemin/api/review/config/RabbitMQConfig.java
+++ b/src/main/java/run/bemin/api/review/config/RabbitMQConfig.java
@@ -1,0 +1,51 @@
+package run.bemin.api.review.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Exchange;
+import org.springframework.amqp.core.ExchangeBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+  // Direct 방식으로 목적지에 전달하기 때문에 directExchange 사용
+  @Bean
+  public Exchange reviewExchange() {
+    return ExchangeBuilder.directExchange("review-exchange").build();
+  }
+
+  // exchange 를 통해 전달할 메시지 큐 이름이 review-queue 인 큐에 전달합니다.
+  @Bean
+  public Queue reviewQueue() {
+    return QueueBuilder.durable("review-queue").build();
+  }
+
+  // exchange 와 queue 를 'review-routing-key'를 통해 연결
+  @Bean
+  public Binding reviewBinding() {
+    return BindingBuilder.bind(reviewQueue()).to(reviewExchange()).with("review-routing-key").noargs();
+  }
+
+  // 메시지 보내고 받기
+  @Bean
+  public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+    RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+    rabbitTemplate.setMessageConverter(jackson2JsonMessageConverter());
+    return rabbitTemplate;
+  }
+
+  // 기본적으로 SimpleMessageConverter 사용되지만, Jackson2JsonMessageConverter 사용해서 객체로 메시지 보내기
+  // 메시지를 JSON 형식으로 변환
+  @Bean
+  public MessageConverter jackson2JsonMessageConverter() {
+    return new Jackson2JsonMessageConverter();
+  }
+}

--- a/src/main/java/run/bemin/api/review/messaging/ReviewConsumer.java
+++ b/src/main/java/run/bemin/api/review/messaging/ReviewConsumer.java
@@ -1,0 +1,35 @@
+package run.bemin.api.review.messaging;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import run.bemin.api.store.entity.Store;
+import run.bemin.api.store.repository.StoreRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReviewConsumer {
+
+  private final StoreRepository storeRepository;
+
+  @Transactional(rollbackFor = Exception.class)   // 예외를 상세하게 보기
+  @RabbitListener(queues = "review-queue")
+  public void receiveReviewEvent(ReviewEvent event) {
+    try {
+      // store 찾기
+      Store store = storeRepository.findById(event.getStoreId()).orElseThrow();
+
+      // store 평점 갱신하기
+      store.updateRating((float) event.getAverageRating());
+
+      // store 데이터베이스에 저장
+      storeRepository.save(store);
+    } catch (Exception e) {
+      // 예외 처리 로직
+      log.info("RabbitMQ 에서 일어난 Error : {}", e.getMessage());
+    }
+  }
+}

--- a/src/main/java/run/bemin/api/review/messaging/ReviewEvent.java
+++ b/src/main/java/run/bemin/api/review/messaging/ReviewEvent.java
@@ -1,0 +1,22 @@
+package run.bemin.api.review.messaging;
+
+import java.util.UUID;
+
+public class ReviewEvent {
+  private UUID storeId;
+  private double averageRating;
+
+  public ReviewEvent(UUID storeId, double averageRating) {
+    this.storeId = storeId;
+    this.averageRating = averageRating;
+  }
+
+  public UUID getStoreId() {
+    return storeId;
+  }
+
+  public double getAverageRating() {
+    return averageRating;
+  }
+}
+

--- a/src/main/java/run/bemin/api/review/messaging/ReviewProducer.java
+++ b/src/main/java/run/bemin/api/review/messaging/ReviewProducer.java
@@ -1,0 +1,22 @@
+package run.bemin.api.review.messaging;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class ReviewProducer {
+
+  private final RabbitTemplate rabbitTemplate;
+
+  @Autowired
+  public ReviewProducer(RabbitTemplate rabbitTemplate) {
+    this.rabbitTemplate = rabbitTemplate;
+  }
+
+  public void sendReviewEvent(ReviewEvent event) {
+    rabbitTemplate.convertAndSend("review-exchange", "review-routing-key", event);
+  }
+}


### PR DESCRIPTION
Review 패키지에 ReviewConsumer, ReviewEvent, ReviewProducer 를 생성 리뷰 데이터가 리뷰 테이블에 생성되면 비동기 처리를 통해 가게의 평점을 계산하고 이를 Store 테이블의 rating 컬럼에 갱신합니다

## ⚙️ PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 🔑 Key Changes

- Review 에 messaging 패키지를 생성하여 RabbitMQ 를 통해 비동기 방식으로 가게의 평점을 갱신하였습니다.
- RabbitMQ 인증 방식 때문에 `AuditorAwareImpl` 공용 패키지를 건드렸습니다! 확인해주시면 좋을거 같아요!

<br/>

## 🤝🏻 To Reviewers

-

<br/>

