### PR TITLE
 Feat: Redis 및 캐시 적용 통해 토큰 관리 및 인증 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,9 @@ dependencies {
     // Hibernate6 모듈 추가 (Hibernate 6 lazy 프록시 직렬화 오류 방지) - 공희진 2/22
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate6:2.18.2'
 
-
+    //Redis 및 캐시 의존성 추천 - 공희진 2/24
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 tasks.named('test') {

--- a/src/main/java/run/bemin/api/auth/controller/AuthSessionController.java
+++ b/src/main/java/run/bemin/api/auth/controller/AuthSessionController.java
@@ -18,8 +18,10 @@ import run.bemin.api.auth.dto.SigninRequestDto;
 import run.bemin.api.auth.dto.SigninResponseDto;
 import run.bemin.api.auth.dto.SignoutResponseDto;
 import run.bemin.api.auth.dto.TokenDto;
+import run.bemin.api.auth.exception.RefreshTokenMissingException;
 import run.bemin.api.auth.jwt.JwtUtil;
 import run.bemin.api.auth.service.AuthService;
+import run.bemin.api.general.exception.ErrorCode;
 import run.bemin.api.general.response.ApiResponse;
 import run.bemin.api.security.UserDetailsImpl;
 
@@ -67,8 +69,7 @@ public class AuthSessionController {
 
     String refreshToken = extractRefreshToken(req);
     if (refreshToken == null) {
-      return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-          .body(ApiResponse.from(HttpStatus.BAD_REQUEST, "Refresh Token 쿠키가 제공되지 않았습니다.", null));
+      throw new RefreshTokenMissingException(ErrorCode.AUTH_REFRESH_TOKEN_MISSING.getMessage());
     }
 
     TokenDto tokenDto = authService.refresh("Bearer " + refreshToken);

--- a/src/main/java/run/bemin/api/auth/dto/RefreshResponseDto.java
+++ b/src/main/java/run/bemin/api/auth/dto/RefreshResponseDto.java
@@ -8,7 +8,7 @@ import run.bemin.api.user.entity.UserRoleEnum;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class SigninResponseDto {
+public class RefreshResponseDto {
   private String accessToken;
   private String email;
   private String nickname;

--- a/src/main/java/run/bemin/api/auth/dto/TokenDto.java
+++ b/src/main/java/run/bemin/api/auth/dto/TokenDto.java
@@ -1,16 +1,26 @@
 package run.bemin.api.auth.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import run.bemin.api.user.entity.UserRoleEnum;
 
-@Getter
+@Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class SigninResponseDto {
+public class TokenDto {
   private String accessToken;
+  private String refreshToken;
+  private long accessTokenExpiresTime;
+  @Getter
+  private long refreshTokenExpiresTime;
+
   private String email;
   private String nickname;
   private UserRoleEnum role;
+
+  public String getToken() {
+    return accessToken;
+  }
 }

--- a/src/main/java/run/bemin/api/auth/exception/RefreshTokenInvalidException.java
+++ b/src/main/java/run/bemin/api/auth/exception/RefreshTokenInvalidException.java
@@ -1,0 +1,7 @@
+package run.bemin.api.auth.exception;
+
+public class RefreshTokenInvalidException extends RuntimeException {
+  public RefreshTokenInvalidException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/run/bemin/api/auth/exception/RefreshTokenMismatchException.java
+++ b/src/main/java/run/bemin/api/auth/exception/RefreshTokenMismatchException.java
@@ -1,0 +1,7 @@
+package run.bemin.api.auth.exception;
+
+public class RefreshTokenMismatchException extends RuntimeException {
+  public RefreshTokenMismatchException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/run/bemin/api/auth/exception/RefreshTokenMissingException.java
+++ b/src/main/java/run/bemin/api/auth/exception/RefreshTokenMissingException.java
@@ -1,0 +1,7 @@
+package run.bemin.api.auth.exception;
+
+public class RefreshTokenMissingException extends RuntimeException {
+  public RefreshTokenMissingException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/run/bemin/api/auth/exception/handler/AuthExceptionHandler.java
+++ b/src/main/java/run/bemin/api/auth/exception/handler/AuthExceptionHandler.java
@@ -1,5 +1,7 @@
 package run.bemin.api.auth.exception.handler;
 
+import static run.bemin.api.general.exception.ErrorCode.AUTH_REFRESH_TOKEN_MISSING;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
@@ -8,6 +10,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import run.bemin.api.auth.exception.AuthAccessDeniedException;
+import run.bemin.api.auth.exception.RefreshTokenMissingException;
 import run.bemin.api.general.exception.ErrorCode;
 import run.bemin.api.general.exception.ErrorResponse;
 
@@ -21,5 +24,12 @@ public class AuthExceptionHandler {
     log.error("Access denied for authentication", e);
     final ErrorResponse response = ErrorResponse.of(ErrorCode.AUTH_ACCESS_DENIED);
     return new ResponseEntity<>(response, HttpStatus.FORBIDDEN);
+  }
+
+  @ExceptionHandler(RefreshTokenMissingException.class)
+  public ResponseEntity<ErrorResponse> handleRefreshTokenMissingException(RefreshTokenMissingException e) {
+    log.error("Refresh Token 쿠키 미제공", e);
+    final ErrorResponse response = ErrorResponse.of(AUTH_REFRESH_TOKEN_MISSING);
+    return new ResponseEntity<>(response, HttpStatus.valueOf(AUTH_REFRESH_TOKEN_MISSING.getStatus()));
   }
 }

--- a/src/main/java/run/bemin/api/auth/exception/handler/AuthExceptionHandler.java
+++ b/src/main/java/run/bemin/api/auth/exception/handler/AuthExceptionHandler.java
@@ -10,6 +10,8 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import run.bemin.api.auth.exception.AuthAccessDeniedException;
+import run.bemin.api.auth.exception.RefreshTokenInvalidException;
+import run.bemin.api.auth.exception.RefreshTokenMismatchException;
 import run.bemin.api.auth.exception.RefreshTokenMissingException;
 import run.bemin.api.general.exception.ErrorCode;
 import run.bemin.api.general.exception.ErrorResponse;
@@ -28,8 +30,22 @@ public class AuthExceptionHandler {
 
   @ExceptionHandler(RefreshTokenMissingException.class)
   public ResponseEntity<ErrorResponse> handleRefreshTokenMissingException(RefreshTokenMissingException e) {
-    log.error("Refresh Token 쿠키 미제공", e);
+    log.error("Refresh Token cookie not provided", e);
     final ErrorResponse response = ErrorResponse.of(AUTH_REFRESH_TOKEN_MISSING);
     return new ResponseEntity<>(response, HttpStatus.valueOf(AUTH_REFRESH_TOKEN_MISSING.getStatus()));
+  }
+
+  @ExceptionHandler(RefreshTokenInvalidException.class)
+  public ResponseEntity<ErrorResponse> handleRefreshTokenInvalidException(RefreshTokenInvalidException e) {
+    log.error("Invalid or expired Refresh Token", e);
+    final ErrorResponse response = ErrorResponse.of(ErrorCode.AUTH_REFRESH_TOKEN_INVALID);
+    return new ResponseEntity<>(response, HttpStatus.valueOf(ErrorCode.AUTH_REFRESH_TOKEN_INVALID.getStatus()));
+  }
+
+  @ExceptionHandler(RefreshTokenMismatchException.class)
+  public ResponseEntity<ErrorResponse> handleRefreshTokenMismatchException(RefreshTokenMismatchException e) {
+    log.error("Stored Refresh Token does not match or has expired", e);
+    final ErrorResponse response = ErrorResponse.of(ErrorCode.AUTH_REFRESH_TOKEN_MISMATCH);
+    return new ResponseEntity<>(response, HttpStatus.valueOf(ErrorCode.AUTH_REFRESH_TOKEN_MISMATCH.getStatus()));
   }
 }

--- a/src/main/java/run/bemin/api/auth/jwt/JwtUtil.java
+++ b/src/main/java/run/bemin/api/auth/jwt/JwtUtil.java
@@ -31,14 +31,10 @@ public class JwtUtil {
   public static final String AUTHORIZATION_KEY = "auth";
   // Token 식별자
   public static final String BEARER_PREFIX = "Bearer ";
-  //  // AccessToken 만료시간 - 1일
-  //  private final long ACCESS_TOKEN_TIME = 24 * 60 * 60 * 1000L;
-
-  // AccessToken 만료시간 - 7분 - Test용
-  private final long ACCESS_TOKEN_TIME = 7 * 60 * 1000L;
-
-  // RefreshToken 만료시간 - 3분
-  private final long REFRESHTOKEN_TIME = 3 * 60 * 1000L;
+  // AccessToken 만료시간 60분
+  private final long ACCESS_TOKEN_TIME = 10 * 60 * 60 * 1000L;
+  // RefreshToken 만료시간 - 24시간
+  private final long REFRESHTOKEN_TIME = 24 * 60 * 60 * 1000L;
 
 
   @Value("${jwt.secret.key}") // Base64 Encode 한 SecretKey

--- a/src/main/java/run/bemin/api/auth/jwt/JwtUtil.java
+++ b/src/main/java/run/bemin/api/auth/jwt/JwtUtil.java
@@ -31,10 +31,15 @@ public class JwtUtil {
   public static final String AUTHORIZATION_KEY = "auth";
   // Token 식별자
   public static final String BEARER_PREFIX = "Bearer ";
-  // AccessToken 만료시간 - 1일
-  private final long ACCESS_TOKEN_TIME = 24 * 60 * 60 * 1000L;
+  //  // AccessToken 만료시간 - 1일
+  //  private final long ACCESS_TOKEN_TIME = 24 * 60 * 60 * 1000L;
+
+  // AccessToken 만료시간 - 7분 - Test용
+  private final long ACCESS_TOKEN_TIME = 7 * 60 * 1000L;
+
   // RefreshToken 만료시간 - 3분
   private final long REFRESHTOKEN_TIME = 3 * 60 * 1000L;
+
 
   @Value("${jwt.secret.key}") // Base64 Encode 한 SecretKey
   public String secretKey; // JwtUtilTokenTest로 인해 public으로 변경했습니다.
@@ -117,4 +122,23 @@ public class JwtUtil {
     Claims claims = getUserInfoFromToken(token);
     return claims.getSubject();
   }
+
+  public long getAccessTokenExpiration() {
+    return ACCESS_TOKEN_TIME; // 예: 24시간
+  }
+
+  public long getRefreshTokenExpiration() {
+    return REFRESHTOKEN_TIME; // 예: 3분 (또는 원하는 시간)
+  }
+
+  public long getRemainingExpirationTime(String token) {
+    // 토큰의 만료 시간을 가져오기
+    Claims claims = getUserInfoFromToken(token);
+    Date expiration = claims.getExpiration();
+    // 현재 시간과 비교하여 남은 시간을 계산 (밀리초 단위)
+    long remainingTime = expiration.getTime() - System.currentTimeMillis();
+    return remainingTime > 0 ? remainingTime : 0;
+  }
+
+
 }

--- a/src/main/java/run/bemin/api/config/CacheConfig.java
+++ b/src/main/java/run/bemin/api/config/CacheConfig.java
@@ -1,0 +1,31 @@
+package run.bemin.api.config;
+
+import java.time.Duration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+  // RedisCacheManager를 빈으로 등록하여 캐시 관리
+  @Bean
+  public RedisCacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
+    RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+        .entryTtl(Duration.ofHours(1)) // 기본 캐시 만료시간
+        .disableCachingNullValues()
+        .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+        .serializeValuesWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+    // RedisConnectionFactory를 사용하여 RedisCacheManager 생성
+    return RedisCacheManager.builder(connectionFactory)
+        .cacheDefaults(config)
+        .build();
+  }
+}

--- a/src/main/java/run/bemin/api/config/RedisRepositoryConfig.java
+++ b/src/main/java/run/bemin/api/config/RedisRepositoryConfig.java
@@ -1,0 +1,35 @@
+package run.bemin.api.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableRedisRepositories
+public class RedisRepositoryConfig {
+
+  private final RedisProperties redisProperties;
+
+  // Redis 연결을 위한 ConnectionFactory 생성
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+  }
+
+  // RedisTemplate 빈을 생성하여 Redis와의 상호작용을 쉽게 함
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate() {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    return redisTemplate;
+  }
+}

--- a/src/main/java/run/bemin/api/config/WebSecurityConfig.java
+++ b/src/main/java/run/bemin/api/config/WebSecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -26,6 +27,7 @@ public class WebSecurityConfig {
 
   private final JwtUtil jwtUtil;
   private final UserDetailsServiceImpl userDetailsService;
+  private final RedisTemplate<String, Object> redisTemplate;
 
   @Bean
   public PasswordEncoder passwordEncoder() {
@@ -39,7 +41,7 @@ public class WebSecurityConfig {
 
   @Bean
   public JwtAuthorizationFilter jwtAuthorizationFilter() {
-    return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
+    return new JwtAuthorizationFilter(jwtUtil, userDetailsService, redisTemplate);
   }
 
   @Bean

--- a/src/main/java/run/bemin/api/general/exception/ErrorCode.java
+++ b/src/main/java/run/bemin/api/general/exception/ErrorCode.java
@@ -30,7 +30,7 @@ public enum ErrorCode {
 
   // 인증/인가 관련 오류
   AUTH_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "A001", "접근이 거부되었습니다."),
-
+  AUTH_REFRESH_TOKEN_MISSING(HttpStatus.BAD_REQUEST.value(), "A002", "Refresh Token 쿠키가 제공되지 않았습니다."),
 
   // Signup (회원가입 관련 오류)
   SIGNUP_DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST.value(), "S001", "이미 존재하는 이메일입니다."),

--- a/src/main/java/run/bemin/api/general/exception/ErrorCode.java
+++ b/src/main/java/run/bemin/api/general/exception/ErrorCode.java
@@ -31,6 +31,8 @@ public enum ErrorCode {
   // 인증/인가 관련 오류
   AUTH_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "A001", "접근이 거부되었습니다."),
   AUTH_REFRESH_TOKEN_MISSING(HttpStatus.BAD_REQUEST.value(), "A002", "Refresh Token 쿠키가 제공되지 않았습니다."),
+  AUTH_REFRESH_TOKEN_INVALID(HttpStatus.BAD_REQUEST.value(), "A003", "유효하지 않거나 만료된 Refresh Token 입니다."),
+  AUTH_REFRESH_TOKEN_MISMATCH(HttpStatus.BAD_REQUEST.value(), "A004", "저장된 Refresh Token과 일치하지 않거나 만료되었습니다."),
 
   // Signup (회원가입 관련 오류)
   SIGNUP_DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST.value(), "S001", "이미 존재하는 이메일입니다."),

--- a/src/main/java/run/bemin/api/security/JwtAuthorizationFilter.java
+++ b/src/main/java/run/bemin/api/security/JwtAuthorizationFilter.java
@@ -1,20 +1,17 @@
 package run.bemin.api.security;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import run.bemin.api.auth.jwt.JwtUtil;
 
@@ -23,10 +20,13 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
   private final JwtUtil jwtUtil;
   private final UserDetailsServiceImpl userDetailsService;
+  private final RedisTemplate<String, Object> redisTemplate;
 
-  public JwtAuthorizationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService) {
+  public JwtAuthorizationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService,
+                                RedisTemplate<String, Object> redisTemplate) {
     this.jwtUtil = jwtUtil;
     this.userDetailsService = userDetailsService;
+    this.redisTemplate = redisTemplate;
   }
 
   @Override
@@ -35,24 +35,16 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     String tokenValue = jwtUtil.getTokenFromHeader(JwtUtil.AUTHORIZATION_HEADER, req);
 
-    if (StringUtils.hasText(tokenValue)) {
-      try {
-        if (!jwtUtil.validateToken(tokenValue)) {
-          log.error("Token Error");
-        }
-
-        Claims info = jwtUtil.getUserInfoFromToken(tokenValue);
-        setAuthentication(info.getSubject());
-
-      } catch (ExpiredJwtException e) {
-        res.setStatus(HttpStatus.UNAUTHORIZED.value());
-        res.setContentType("application/json");
-        res.setCharacterEncoding("UTF-8");
-        res.getWriter().write("{\"message\":\"리프레시 토큰으로 재발급 받으세요\"}");
-
-        return;
-      } catch (Exception e) {
-        log.error(e.getMessage());
+    if (tokenValue != null && jwtUtil.validateToken(tokenValue)) {
+      // Redis에서 토큰이 블랙리스트에 등록되어 있는지 확인
+      String isLogout = (String) redisTemplate.opsForValue().get(tokenValue);
+      if (isLogout == null) { // 블랙리스트에 없다면 정상 인증
+        String username = jwtUtil.getUserEmailFromToken(tokenValue);
+        setAuthentication(username);
+      } else {
+        // 블랙리스트에 있다면 인증을 무시하거나 오류 응답 처리
+        res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        res.getWriter().write("{\"message\": \"로그아웃된 토큰입니다.\"}");
         return;
       }
     }

--- a/src/main/java/run/bemin/api/user/controller/UserController.java
+++ b/src/main/java/run/bemin/api/user/controller/UserController.java
@@ -26,6 +26,7 @@ import run.bemin.api.user.dto.UserAddressRequestDto;
 import run.bemin.api.user.dto.UserAddressResponseDto;
 import run.bemin.api.user.dto.UserResponseDto;
 import run.bemin.api.user.dto.UserUpdateRequestDto;
+import run.bemin.api.user.entity.UserRoleEnum;
 import run.bemin.api.user.exception.UserUnauthorizedException;
 import run.bemin.api.user.service.UserAddressService;
 import run.bemin.api.user.service.UserService;
@@ -47,14 +48,16 @@ public class UserController {
   public ResponseEntity<ApiResponse<Page<UserResponseDto>>> getAllUsers(
       @RequestParam(value = "page", defaultValue = "0") Integer page,
       @RequestParam(value = "size", defaultValue = "10") Integer size,
-      @RequestParam(value = "isDeleted", required = false) Boolean isDeleted
+      @RequestParam(value = "isDeleted", required = false) Boolean isDeleted,
+      @RequestParam(value = "role", required = false) UserRoleEnum role
   ) {
     Page<UserResponseDto> users = userService.getAllUsers(
         isDeleted,
         page,
         size,
         "createdAt",
-        true
+        true,
+        role
     );
     return ResponseEntity.ok(ApiResponse.from(HttpStatus.OK, "성공", users));
   }

--- a/src/main/java/run/bemin/api/user/entity/UserAddress.java
+++ b/src/main/java/run/bemin/api/user/entity/UserAddress.java
@@ -12,6 +12,7 @@ import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,6 +20,8 @@ import run.bemin.api.general.auditing.AuditableEntity;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 @Entity(name = "p_user_address")
 public class UserAddress extends AuditableEntity {
 
@@ -40,6 +43,7 @@ public class UserAddress extends AuditableEntity {
   private String detail;
 
   // 대표 주소 여부 플래그
+  @Builder.Default
   @Column(name = "is_representative", nullable = false)
   private Boolean isRepresentative = false;
 
@@ -48,6 +52,7 @@ public class UserAddress extends AuditableEntity {
   @JsonBackReference // User의 userAddressList에 대한 역참조를 무시
   private User user;
 
+  @Builder.Default
   @Column(name = "is_deleted", nullable = false)
   private Boolean isDeleted = false;
 

--- a/src/main/java/run/bemin/api/user/repository/UserRepository.java
+++ b/src/main/java/run/bemin/api/user/repository/UserRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import run.bemin.api.user.entity.User;
+import run.bemin.api.user.entity.UserRoleEnum;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, String> {
@@ -16,5 +17,9 @@ public interface UserRepository extends JpaRepository<User, String> {
   boolean existsByNickname(String nickname);
 
   Page<User> findByIsDeleted(Boolean isDeleted, Pageable pageable);
+
+  Page<User> findByRole(UserRoleEnum role, Pageable pageable);
+
+  Page<User> findByIsDeletedAndRole(Boolean isDeleted, UserRoleEnum role, Pageable pageable);
 
 }

--- a/src/main/java/run/bemin/api/user/service/UserService.java
+++ b/src/main/java/run/bemin/api/user/service/UserService.java
@@ -12,6 +12,7 @@ import run.bemin.api.general.exception.ErrorCode;
 import run.bemin.api.user.dto.UserResponseDto;
 import run.bemin.api.user.dto.UserUpdateRequestDto;
 import run.bemin.api.user.entity.User;
+import run.bemin.api.user.entity.UserRoleEnum;
 import run.bemin.api.user.exception.UserDuplicateNicknameException;
 import run.bemin.api.user.exception.UserListNotFoundException;
 import run.bemin.api.user.exception.UserNoFieldUpdatedException;
@@ -34,16 +35,25 @@ public class UserService {
                                            Integer page,
                                            Integer size,
                                            String sortBy,
-                                           Boolean isAsc) {
+                                           Boolean isAsc,
+                                           UserRoleEnum role) {
     Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
     Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
 
     Page<User> userPage;
     try {
       if (isDeleted == null) {
-        userPage = userRepository.findAll(pageable);
+        if (role == null) {
+          userPage = userRepository.findAll(pageable);
+        } else {
+          userPage = userRepository.findByRole(role, pageable);
+        }
       } else {
-        userPage = userRepository.findByIsDeleted(isDeleted, pageable);
+        if (role == null) {
+          userPage = userRepository.findByIsDeleted(isDeleted, pageable);
+        } else {
+          userPage = userRepository.findByIsDeletedAndRole(isDeleted, role, pageable);
+        }
       }
     } catch (Exception e) {
       throw new UserRetrievalFailedException(ErrorCode.USER_RETRIEVAL_FAILED.getMessage());
@@ -55,7 +65,6 @@ public class UserService {
 
     return userPage.map(UserResponseDto::fromEntity);
   }
-
 
   /**
    * 특정 회원 조회

--- a/src/test/java/run/bemin/api/auth/controller/AuthSessionControllerTest.java
+++ b/src/test/java/run/bemin/api/auth/controller/AuthSessionControllerTest.java
@@ -1,5 +1,9 @@
 package run.bemin.api.auth.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
@@ -10,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,12 +23,13 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import run.bemin.api.auth.dto.SigninRequestDto;
-import run.bemin.api.auth.dto.SigninResponseDto;
+import run.bemin.api.auth.dto.TokenDto;
 import run.bemin.api.auth.jwt.JwtUtil;
 import run.bemin.api.auth.service.AuthService;
 import run.bemin.api.config.MockConfig;
@@ -32,6 +38,7 @@ import run.bemin.api.config.WebSecurityConfig;
 import run.bemin.api.security.UserDetailsImpl;
 import run.bemin.api.user.entity.User;
 import run.bemin.api.user.entity.UserRoleEnum;
+
 
 @WebMvcTest(
     controllers = AuthSessionController.class,
@@ -51,7 +58,15 @@ class AuthSessionControllerTest {
   @Autowired
   private ObjectMapper objectMapper;
 
+  @Autowired
   private MockMvc mockMvc;
+
+  @Autowired
+  private JwtUtil jwtUtil;
+
+  @Autowired
+  private RedisTemplate<String, Object> redisTemplate;
+  ;
 
   @Autowired
   private AuthService authService;
@@ -68,32 +83,29 @@ class AuthSessionControllerTest {
   void signinSuccessTest() throws Exception {
     // Given
     SigninRequestDto requestDto = SigninRequestDto.builder()
-        .userEmail("test@gmail.com")
-        .password("test1234")
+        .userEmail("user1@gmail.com")
+        .password("user1234")
         .build();
 
-    SigninResponseDto responseDto = new SigninResponseDto(
-        "testToken",
-        "test@gmail.com",
-        "testUser",
-        UserRoleEnum.CUSTOMER
-    );
-
-//    when(authService.signin(anyString(), anyString())).thenReturn(responseDto);
+    TokenDto tokenDto = new TokenDto("testToken", "Bearer testRefreshToken", 1000L, 2000L,
+        "user1@gmail.com", "user1", UserRoleEnum.CUSTOMER);
+    when(authService.signin("user1@gmail.com", "user1234")).thenReturn(tokenDto);
+    when(jwtUtil.getRefreshTokenExpiration()).thenReturn(2000L);
 
     // When & Then
     mockMvc.perform(post("/api/auth/signin")
             .with(csrf())
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(requestDto))
-        )
+            .content(objectMapper.writeValueAsString(requestDto)))
         .andExpect(status().isOk())
-        // 헤더에 JWT 토큰이 담기는지 확인
         .andExpect(header().string(JwtUtil.AUTHORIZATION_HEADER, "testToken"))
-        // JSON 응답 검증
         .andExpect(jsonPath("$.message").value("성공"))
-        .andExpect(jsonPath("$.data.token").value("testToken"))
-        .andExpect(jsonPath("$.data.email").value("test@gmail.com"))
+        .andExpect(jsonPath("$.data.accessToken").value("testToken"))
+        .andExpect(jsonPath("$.data.email").value("user1@gmail.com"))
+        .andDo(result -> {
+          String setCookie = result.getResponse().getHeader("Set-Cookie");
+          System.out.println("Set-Cookie: " + setCookie);
+        })
         .andDo(print());
   }
 
@@ -127,6 +139,44 @@ class AuthSessionControllerTest {
   }
 
   @Test
+  @DisplayName("리프레시 토큰 성공 테스트")
+  void refreshTokenSuccessTest() throws Exception {
+
+    // Given
+    String cookieRefreshToken = "testRefreshToken";
+    String refreshToken = "Bearer " + cookieRefreshToken;
+
+    when(jwtUtil.validateToken(cookieRefreshToken)).thenReturn(true);
+    when(jwtUtil.getUserEmailFromToken(cookieRefreshToken)).thenReturn("test@gmail.com");
+    when(jwtUtil.createAccessToken("test@gmail.com", UserRoleEnum.CUSTOMER)).thenReturn("newAccessToken");
+    when(jwtUtil.createRefreshToken("test@gmail.com")).thenReturn("Bearer newRefreshToken");
+    when(jwtUtil.getAccessTokenExpiration()).thenReturn(1000L);
+    when(jwtUtil.getRefreshTokenExpiration()).thenReturn(2000L);
+
+    TokenDto tokenDto = new TokenDto("newAccessToken", "Bearer newRefreshToken", 1000L, 2000L,
+        "test@gmail.com", "testUser", UserRoleEnum.CUSTOMER);
+    when(authService.refresh(refreshToken)).thenReturn(tokenDto);
+
+    // When & Then
+    mockMvc.perform(post("/api/auth/refresh")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            // refresh 엔드포인트는 쿠키에서 refresh 토큰을 추출
+            .cookie(new jakarta.servlet.http.Cookie("refresh", cookieRefreshToken)))
+        .andExpect(status().isOk())
+        .andExpect(header().string(JwtUtil.AUTHORIZATION_HEADER, "newAccessToken"))
+        .andExpect(jsonPath("$.message").value("토큰 갱신 성공"))
+        .andExpect(jsonPath("$.data.accessToken").value("newAccessToken"))
+        .andDo(result -> {
+          String setCookie = result.getResponse().getHeader("Set-Cookie");
+          System.out.println("Set-Cookie (refresh): " + setCookie);
+        })
+        .andDo(print());
+
+  }
+
+
+  @Test
   @DisplayName("로그아웃 성공 테스트")
   void signoutSuccessTest() throws Exception {
     // Given
@@ -136,14 +186,21 @@ class AuthSessionControllerTest {
         .build();
     UserDetailsImpl userDetails = new UserDetailsImpl(testUser);
 
+    when(jwtUtil.getTokenFromHeader(eq(JwtUtil.AUTHORIZATION_HEADER), any(HttpServletRequest.class)))
+        .thenReturn("someAccessToken");
+    
+    doNothing().when(authService).signout("someAccessToken", "test@gmail.com");
+
     // When & Then
     mockMvc.perform(post("/api/auth/signout")
             .with(user(userDetails))  // 인증된 사용자로 요청
-            .with(csrf()))
+            .with(csrf())
+            .header(JwtUtil.AUTHORIZATION_HEADER, "Bearer someAccessToken"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.message").value("로그아웃 성공"))
         .andExpect(jsonPath("$.data.userEmail").value("test@gmail.com"))
         .andExpect(jsonPath("$.data.message").value("로그아웃 성공"))
         .andDo(print());
   }
+
 }

--- a/src/test/java/run/bemin/api/auth/controller/AuthSessionControllerTest.java
+++ b/src/test/java/run/bemin/api/auth/controller/AuthSessionControllerTest.java
@@ -1,7 +1,5 @@
 package run.bemin.api.auth.controller;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
@@ -81,7 +79,7 @@ class AuthSessionControllerTest {
         UserRoleEnum.CUSTOMER
     );
 
-    when(authService.signin(anyString(), anyString())).thenReturn(responseDto);
+//    when(authService.signin(anyString(), anyString())).thenReturn(responseDto);
 
     // When & Then
     mockMvc.perform(post("/api/auth/signin")

--- a/src/test/java/run/bemin/api/config/MockConfig.java
+++ b/src/test/java/run/bemin/api/config/MockConfig.java
@@ -4,11 +4,23 @@ import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import run.bemin.api.auth.service.AuthService;
+import run.bemin.api.user.service.UserAddressService;
+import run.bemin.api.user.service.UserService;
 
 @TestConfiguration
 public class MockConfig {
   @Bean
   public AuthService authService() {
     return Mockito.mock(AuthService.class);
+  }
+
+  @Bean
+  public UserService userService() {
+    return Mockito.mock(UserService.class);
+  }
+
+  @Bean
+  public UserAddressService userAddressService() {
+    return Mockito.mock(UserAddressService.class);
   }
 }

--- a/src/test/java/run/bemin/api/config/MockConfig.java
+++ b/src/test/java/run/bemin/api/config/MockConfig.java
@@ -3,6 +3,8 @@ package run.bemin.api.config;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.core.RedisTemplate;
+import run.bemin.api.auth.jwt.JwtUtil;
 import run.bemin.api.auth.service.AuthService;
 import run.bemin.api.user.service.UserAddressService;
 import run.bemin.api.user.service.UserService;
@@ -12,6 +14,16 @@ public class MockConfig {
   @Bean
   public AuthService authService() {
     return Mockito.mock(AuthService.class);
+  }
+
+  @Bean
+  public JwtUtil jwtUtil() {
+    return Mockito.mock(JwtUtil.class);
+  }
+
+  @Bean
+  public RedisTemplate redisTemplate() {
+    return Mockito.mock(RedisTemplate.class);
   }
 
   @Bean

--- a/src/test/java/run/bemin/api/user/controller/UserControllerTest.java
+++ b/src/test/java/run/bemin/api/user/controller/UserControllerTest.java
@@ -1,0 +1,387 @@
+package run.bemin.api.user.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import run.bemin.api.config.MockConfig;
+import run.bemin.api.config.TestSecurityConfig;
+import run.bemin.api.config.WebSecurityConfig;
+import run.bemin.api.security.UserDetailsImpl;
+import run.bemin.api.user.dto.UserAddressRequestDto;
+import run.bemin.api.user.dto.UserAddressResponseDto;
+import run.bemin.api.user.dto.UserResponseDto;
+import run.bemin.api.user.dto.UserUpdateRequestDto;
+import run.bemin.api.user.entity.User;
+import run.bemin.api.user.entity.UserAddress;
+import run.bemin.api.user.entity.UserRoleEnum;
+import run.bemin.api.user.service.UserAddressService;
+import run.bemin.api.user.service.UserService;
+
+@WebMvcTest(
+    controllers = UserController.class,
+    excludeFilters = {
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = WebSecurityConfig.class
+        )
+    }
+)
+@Import({MockConfig.class, TestSecurityConfig.class})
+class UserControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private UserService userService;
+
+  @Autowired
+  private UserAddressService userAddressService;
+
+
+  @Test
+  @DisplayName("전체 사용자 조회 테스트 - MASTER 권한")
+  void getAllUsersSuccessTest() throws Exception {
+    // Given
+    UserResponseDto userDto1 = new UserResponseDto("user1@test.com", "User1", "user1", "010-1111-1111", null,
+        UserRoleEnum.CUSTOMER, true);
+    UserResponseDto userDto2 = new UserResponseDto("user2@test.com", "User2", "user2", "010-2222-2222", null,
+        UserRoleEnum.MASTER, false);
+    Page<UserResponseDto> page = new PageImpl<>(Arrays.asList(userDto1, userDto2),
+        PageRequest.of(0, 10, Sort.by("createdAt")), 2);
+
+    when(userService.getAllUsers(null, 0, 10, "createdAt", true, null))
+        .thenReturn(page);
+
+    // When & Then
+    mockMvc.perform(get("/api/users")
+            .with(csrf())
+            .with(user("masterUser").roles("MASTER"))
+            .param("page", "0")
+            .param("size", "10")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("성공"))
+        .andExpect(jsonPath("$.data.content").isArray())
+        .andExpect(jsonPath("$.data.content.length()").value(2))
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("내 정보 조회 테스트")
+  void myInfoSuccessTest() throws Exception {
+    // Given
+    String addressId = UUID.randomUUID().toString();
+    UserResponseDto dto = new UserResponseDto(
+        "user1@test.com",
+        "user1",
+        "nickname",
+        "010-1111-1111",
+        addressId,
+        UserRoleEnum.CUSTOMER,
+        false);
+
+    when(userService.getUserByUserEmail("user1@test.com")).thenReturn(dto);
+
+    User mockUser = User.builder()
+        .userEmail("user1@test.com")
+        .role(UserRoleEnum.CUSTOMER)
+        .build();
+
+    UserDetailsImpl userDetails = new UserDetailsImpl(mockUser);
+
+    // When & Then
+    mockMvc.perform(get("/api/users/my-info")
+            .with(csrf())
+            .with(user(userDetails))
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("성공"))
+        .andExpect(jsonPath("$.data.userEmail").value("user1@test.com"))
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("내 정보 수정 테스트")
+  void myInfoupdateTest() throws Exception {
+    String addressId = UUID.randomUUID().toString();
+    UserUpdateRequestDto requestDto = UserUpdateRequestDto.builder()
+        .nickname("newnick")
+        .phone("010-1111-2222")
+        .build();
+
+    UserResponseDto updatedDto = new UserResponseDto(
+        "user1@test.com",
+        "user1",
+        "newnick",
+        "010-1111-2222",
+        addressId,
+        UserRoleEnum.CUSTOMER,
+        false);
+
+    when(userService.updateUser(eq("user1@test.com"), any(UserUpdateRequestDto.class)))
+        .thenReturn(updatedDto);
+
+    User mockUser = User.builder()
+        .userEmail("user1@test.com")
+        .role(UserRoleEnum.CUSTOMER)
+        .build();
+
+    UserDetailsImpl userDetails = new UserDetailsImpl(mockUser);
+
+    mockMvc.perform(put("/api/users/my-info")
+            .with(csrf())
+            .with(user(userDetails))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(requestDto)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("성공"))
+        .andExpect(jsonPath("$.data.userEmail").value("user1@test.com"))
+        .andExpect(jsonPath("$.data.phone").value(requestDto.getPhone()))
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("특정 회원 조회 테스트 - MASTER 권한")
+  void testGetUserByUserEmail() throws Exception {
+    String addressId = UUID.randomUUID().toString();
+    UserResponseDto dto = new UserResponseDto(
+        "user1@test.com", "user1", "user1", "010-3333-3333", addressId, UserRoleEnum.CUSTOMER, false);
+    when(userService.getUserByUserEmail("user1@test.com")).thenReturn(dto);
+
+    mockMvc.perform(get("/api/users/user1@test.com")
+            .with(csrf())
+            .with(user("master@test.com").roles("MASTER")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("성공"))
+        .andExpect(jsonPath("$.data.userEmail").value("user1@test.com"))
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("특정 회원 수정 테스트")
+  void testUpdateUser() throws Exception {
+    String addressId = UUID.randomUUID().toString();
+    UserUpdateRequestDto requestDto = UserUpdateRequestDto.builder()
+        .nickname("newnick")
+        .phone("010-4444-4444")
+        .build();
+
+    UserResponseDto updatedDto = new UserResponseDto(
+        "user1@test.com",
+        "newname",
+        "newnick",
+        "010-4444-4444",
+        addressId,
+        UserRoleEnum.CUSTOMER, false);
+    when(userService.updateUser(eq("user1@test.com"), any(UserUpdateRequestDto.class)))
+        .thenReturn(updatedDto);
+
+    User mockUser = User.builder()
+        .userEmail("user1@test.com")
+        .role(UserRoleEnum.CUSTOMER)
+        .build();
+
+    UserDetailsImpl userDetails = new UserDetailsImpl(mockUser);
+
+    mockMvc.perform(put("/api/users/user@test.com")
+            .with(csrf())
+            .with(user(userDetails))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(requestDto)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userEmail").value("user1@test.com"))
+        .andExpect(jsonPath("$.name").value("newname"))
+        .andExpect(jsonPath("$.nickname").value("newnick"))
+        .andExpect(jsonPath("$.phone").value("010-4444-4444"))
+        .andDo(print());
+  }
+
+
+  @Test
+  @DisplayName("회원 소프트 삭제 테스트")
+  void testSoftDeleteUser() throws Exception {
+    // userService.softDeleteUser(...) 호출 시 deletedUserDto 반환
+    doNothing().when(userService).softDeleteUser("user1@test.com", "user@test.com");
+
+    User mockUser = User.builder()
+        .userEmail("user1@test.com")
+        .role(UserRoleEnum.CUSTOMER)
+        .build();
+    UserDetailsImpl userDetails = new UserDetailsImpl(mockUser);
+
+    mockMvc.perform(delete("/api/users/user1@test.com")
+            .with(csrf())
+            .with(user(userDetails)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("성공"))
+        .andDo(print());
+
+  }
+
+
+  @Test
+  @DisplayName("특정 사용자 주소 전체 조회 테스트")
+  void testGetAddresses() throws Exception {
+    UUID randomRepresentativeAddress = UUID.randomUUID();
+    UserAddress userAddress1 = UserAddress.builder()
+        .id(randomRepresentativeAddress)
+        .bcode("12345")
+        .jibunAddress("서울시 강남구 97-45")
+        .roadAddress("서울시 강남구 테헤란로 40")
+        .detail("101호")
+        .isRepresentative(true)
+        .build();
+
+    UserAddress userAddress2 = UserAddress.builder()
+        .id(randomRepresentativeAddress)
+        .bcode("0000")
+        .jibunAddress("서울시 강남구 123-45")
+        .roadAddress("서울시 강남구 테헤란로 10")
+        .detail("101호")
+        .isRepresentative(false)
+        .build();
+
+    UserAddressResponseDto addressDto1 = UserAddressResponseDto.fromEntity(userAddress1);
+    UserAddressResponseDto addressDto2 = UserAddressResponseDto.fromEntity(userAddress2);
+
+    Page<UserAddressResponseDto> page = new PageImpl<>(Arrays.asList(addressDto1, addressDto2),
+        PageRequest.of(0, 10, Sort.by("createdAt")), 2);
+
+    when(userAddressService.getAllAddresses("user1@test.com", false, 0, 10))
+        .thenReturn(page);
+
+    User mockUser = User.builder()
+        .userEmail("user1@test.com")
+        .role(UserRoleEnum.CUSTOMER)
+        .build();
+
+    UserDetailsImpl userDetails = new UserDetailsImpl(mockUser);
+
+    mockMvc.perform(get("/api/users/user1@test.com/addresses")
+            .with(csrf())
+            .with(user(userDetails))
+            .param("page", "0")
+            .param("size", "10"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("주소 목록 조회 성공"))
+        .andExpect(jsonPath("$.data.content").isArray())
+        .andExpect(jsonPath("$.data.page.totalElements").value(2))
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("배달 주소 추가 테스트")
+  void testAddAddress() throws Exception {
+    // Given
+    UserAddressRequestDto requestDto = UserAddressRequestDto.builder()
+        .roadAddress("서울시 강남구 테헤란로 10")
+        .jibunAddress("서울시 강남구 123-45")
+        .bcode("00000")
+        .detail("101호")
+        .build();
+    //새로 추가 되는 주소 (대표 주소로 자동 등록)
+    UserAddress dummyAddress = UserAddress.builder()
+        .id(UUID.randomUUID())
+        .bcode(requestDto.getBcode())
+        .jibunAddress(requestDto.getJibunAddress())
+        .roadAddress(requestDto.getRoadAddress())
+        .detail(requestDto.getDetail())
+        .isRepresentative(true)
+        .build();
+    UserAddressResponseDto responseDto = UserAddressResponseDto.fromEntity(dummyAddress);
+
+    // When
+    when(userAddressService.addAddress(eq("user1@test.com"), any(UserAddressRequestDto.class)))
+        .thenReturn(responseDto);
+
+    User mockUser = User.builder()
+        .userEmail("user1@test.com")
+        .role(UserRoleEnum.CUSTOMER)
+        .build();
+
+    UserDetailsImpl userDetails = new UserDetailsImpl(mockUser);
+
+    // Then
+    mockMvc.perform(post("/api/users/user1@test.com/addresses")
+            .with(csrf())
+            .with(user(userDetails))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(requestDto)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("배달 주소 추가 성공"))
+        .andExpect(jsonPath("$.data.representative").value(true)) // 새로 추가된 주소가 대표 주소로 설정되었는지 확인
+        .andExpect(jsonPath("$.data.roadAddress").value(requestDto.getRoadAddress()))
+        .andDo(print());
+  }
+
+
+  @Test
+  @DisplayName("대표 배달 주소로 변경 테스트")
+  void testSetRepresentativeAddress() throws Exception {
+    // Give
+    UUID addressId = UUID.randomUUID();
+
+    UserAddress dummyAddress = UserAddress.builder()
+        .id(addressId)
+        .bcode("12345")
+        .jibunAddress("서울시 강남구 97-45")
+        .roadAddress("서울시 강남구 테헤란로 40")
+        .detail("101호")
+        .isRepresentative(true)
+        .build();
+    UserAddressResponseDto updatedAddressDto = UserAddressResponseDto.fromEntity(dummyAddress);
+
+    // When
+    when(userAddressService.setRepresentativeAddress("user1@test.com", addressId))
+        .thenReturn(updatedAddressDto);
+
+    User mockUser = User.builder()
+        .userEmail("user1@test.com")
+        .role(UserRoleEnum.CUSTOMER)
+        .build();
+
+    UserDetailsImpl userDetails = new UserDetailsImpl(mockUser);
+
+    // Then
+    mockMvc.perform(put("/api/users/user1@test.com/addresses/" + addressId + "/representative")
+            .with(csrf())
+            .with(user(userDetails)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("대표 주소로 변경 성공"))
+        .andExpect(jsonPath("$.data.userAddressId").value(addressId.toString()))
+        .andDo(print());
+  }
+
+}
+

--- a/src/test/java/run/bemin/api/user/service/UserAddressServiceTest.java
+++ b/src/test/java/run/bemin/api/user/service/UserAddressServiceTest.java
@@ -1,0 +1,220 @@
+package run.bemin.api.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import run.bemin.api.user.dto.UserAddressRequestDto;
+import run.bemin.api.user.dto.UserAddressResponseDto;
+import run.bemin.api.user.entity.User;
+import run.bemin.api.user.entity.UserAddress;
+import run.bemin.api.user.entity.UserRoleEnum;
+import run.bemin.api.user.exception.UserAddressNotFoundException;
+import run.bemin.api.user.repository.UserAddressRepository;
+import run.bemin.api.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class UserAddressServiceTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private UserAddressRepository userAddressRepository;
+
+  @InjectMocks
+  private UserAddressService userAddressService;
+
+  private User user1;
+  private User user2;
+  private UserAddress addressExisting;
+  private UserAddress addressNew;
+  private UserAddress addressOld;
+  private UserAddressRequestDto addressRequestDto;
+
+  @BeforeEach
+  void setUp() {
+    user1 = User.builder()
+        .userEmail("user1@test.com")
+        .name("User1")
+        .nickname("user1")
+        .phone("010-1111-1111")
+        .role(UserRoleEnum.CUSTOMER)
+        .build();
+
+    user2 = User.builder()
+        .userEmail("user2@test.com")
+        .name("User2")
+        .nickname("user2")
+        .phone("010-2222-2222")
+        .role(UserRoleEnum.CUSTOMER)
+        .build();
+
+    // 기존 대표 주소
+    addressExisting = UserAddress.builder()
+        .id(UUID.randomUUID())
+        .bcode("oldBcode")
+        .jibunAddress("old jibun")
+        .roadAddress("old road")
+        .detail("old detail")
+        .isRepresentative(true)
+        .user(user1)
+        .build();
+
+    addressRequestDto = UserAddressRequestDto.builder()
+        .bcode("newBcode")
+        .jibunAddress("new jibun")
+        .roadAddress("new road")
+        .detail("new detail")
+        .build();
+
+    // 새로운 주소 엔티티
+    addressNew = UserAddress.builder()
+        .id(UUID.randomUUID())
+        .bcode(addressRequestDto.getBcode())
+        .jibunAddress(addressRequestDto.getJibunAddress())
+        .roadAddress(addressRequestDto.getRoadAddress())
+        .detail(addressRequestDto.getDetail())
+        .isRepresentative(true)
+        .user(user1)
+        .build();
+
+    addressOld = UserAddress.builder()
+        .id(UUID.randomUUID())
+        .bcode("oldBcode")
+        .jibunAddress("old jibun")
+        .roadAddress("old road")
+        .detail("old detail")
+        .isRepresentative(false)
+        .user(user2)
+        .build();
+
+    addressNew = UserAddress.builder()
+        .id(UUID.randomUUID())
+        .bcode(addressRequestDto.getBcode())
+        .jibunAddress(addressRequestDto.getJibunAddress())
+        .roadAddress(addressRequestDto.getRoadAddress())
+        .detail(addressRequestDto.getDetail())
+        .isRepresentative(true)
+        .user(user2)
+        .build();
+
+
+  }
+
+  @Test
+  @DisplayName("특정 회원의 배달 주소 추가 - addAddress() 성공")
+  void addAddress_success() {
+    // Given
+    when(userRepository.findByUserEmail("user1@test.com")).thenReturn(Optional.of(user1));
+
+    when(userAddressRepository.findByUserAndIsRepresentativeTrue(user1))
+        .thenReturn(Collections.singletonList(addressExisting));
+
+    // 새로운 주소 저장
+    when(userAddressRepository.save(any(UserAddress.class))).thenReturn(addressNew);
+
+    // When
+    UserAddressResponseDto responseDto = userAddressService.addAddress("user1@test.com", addressRequestDto);
+
+    // Then
+    // 기존 대표 주소의 isRepresentative가 false로 변경되었는지 확인
+    assertThat(addressExisting.getIsRepresentative()).isFalse();
+    // 새로운 주소가 대표 주소로 설정되었는지 확인
+    assertThat(responseDto.getBcode()).isEqualTo("newBcode");
+    assertThat(responseDto.isRepresentative()).isTrue();
+    // 회원의 대표 주소가 새 주소로 업데이트되었는지 확인
+    assertEquals(addressNew, user1.getRepresentativeAddress());
+    assertEquals(false, addressExisting.getIsRepresentative());
+
+    System.out.println("old address: "
+        + addressExisting.getIsRepresentative());
+    System.out.println("new address  " + responseDto.isRepresentative());
+  }
+
+  @Test
+  @DisplayName("특정 회원의 주소 목록 조회 - getAllAddresses() 성공")
+  void getAllAddressesTest() {
+    // Given
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "createdAt"));
+    // 회원 조회
+    when(userRepository.findByUserEmail("user2@test.com")).thenReturn(Optional.of(user2));
+
+    Page<UserAddress> addressPage = new PageImpl<>(Arrays.asList(addressOld, addressNew), pageable, 2);
+    when(userAddressRepository.findByUserAndIsDeleted(eq(user2), eq(false), any(Pageable.class)))
+        .thenReturn(addressPage);
+
+    // When
+    Page<UserAddressResponseDto> result = userAddressService.getAllAddresses("user2@test.com", false, 0, 10);
+
+    // Then
+    System.out.println("주소 목록 조회 결과: " + result);
+    result.getContent().forEach(dto -> {
+      System.out.println("주소: " + dto.getBcode() + ", isRepresentative: " + dto.isRepresentative());
+    });
+
+    assertThat(result).hasSize(2);
+  }
+
+  @Test
+  @DisplayName("회원 대표 주소 변경 - setRepresentativeAddress() 성공")
+  void setRepresentativeAddressTest() {
+    // Given
+    when(userRepository.findByUserEmail("user2@test.com")).thenReturn(Optional.of(user2));
+    when(userAddressRepository.findByUserAndIsRepresentativeTrue(user2))
+        .thenReturn(Arrays.asList(addressNew));
+    // 기존 대표 주소(addressNew) 업데이트 시 호출
+    when(userAddressRepository.save(addressNew)).thenReturn(addressNew);
+
+    // 새로 대표 주소(addressOld)로 지정
+    UUID newAddressId = addressOld.getId();
+    when(userAddressRepository.findById(newAddressId)).thenReturn(Optional.of(addressOld));
+    when(userAddressRepository.save(addressOld)).thenReturn(addressOld);
+    when(userRepository.save(user2)).thenReturn(user2);
+
+    // When
+    UserAddressResponseDto responseDto = userAddressService.setRepresentativeAddress("user2@test.com", newAddressId);
+
+    // Then
+    // 기존 대표 주소(addressNew)가 해제되었고, 새 주소(addressOld)가 대표 주소로 설정
+    assertThat(addressNew.getIsRepresentative()).isFalse();
+    assertThat(addressOld.getIsRepresentative()).isTrue();
+    assertEquals(addressOld, user2.getRepresentativeAddress());
+    System.out.println("대표 주소 변경 후: " + responseDto.getJibunAddress());
+  }
+
+  @Test
+  @DisplayName("회원 대표 주소 변경 실패 - 해당 주소가 존재하지 않을 경우")
+  void setRepresentativeAddress_failure_notFound() {
+    // Given
+    when(userRepository.findByUserEmail("user1@test.com")).thenReturn(Optional.of(user1));
+    UUID nonExistentId = UUID.randomUUID();
+    when(userAddressRepository.findById(nonExistentId)).thenReturn(Optional.empty());
+
+    // When & Then
+    UserAddressNotFoundException exception = assertThrows(UserAddressNotFoundException.class,
+        () -> userAddressService.setRepresentativeAddress("user1@test.com", nonExistentId));
+
+    System.out.println("Expected exception occurred: " + exception.getMessage());
+  }
+
+}

--- a/src/test/java/run/bemin/api/user/service/UserServiceTest.java
+++ b/src/test/java/run/bemin/api/user/service/UserServiceTest.java
@@ -1,0 +1,351 @@
+package run.bemin.api.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import run.bemin.api.user.dto.UserResponseDto;
+import run.bemin.api.user.dto.UserUpdateRequestDto;
+import run.bemin.api.user.entity.User;
+import run.bemin.api.user.entity.UserRoleEnum;
+import run.bemin.api.user.exception.UserDuplicateNicknameException;
+import run.bemin.api.user.exception.UserListNotFoundException;
+import run.bemin.api.user.exception.UserNoFieldUpdatedException;
+import run.bemin.api.user.exception.UserNotFoundException;
+import run.bemin.api.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private PasswordEncoder passwordEncoder;
+
+  @InjectMocks
+  private UserService userService;
+
+  private User user1, user2, user3;
+
+  @BeforeEach
+  void setUp() {
+    user1 = User.builder()
+        .userEmail("user1@test.com")
+        .name("User1")
+        .nickname("user1")
+        .phone("010-1111-1111")
+        .role(UserRoleEnum.CUSTOMER)
+        .build();
+
+    user2 = User.builder()
+        .userEmail("user2@test.com")
+        .name("User2")
+        .nickname("user2")
+        .phone("010-2222-2222")
+        .isDeleted(true)
+        .role(UserRoleEnum.MASTER)
+        .build();
+
+    user3 = User.builder()
+        .userEmail("user3@test.com")
+        .name("User3")
+        .nickname("user3")
+        .phone("010-3333-3333")
+        .role(UserRoleEnum.CUSTOMER)
+        .build();
+  }
+
+  @Test
+  @DisplayName("전체 회원 조회 성공 테스트 - 전체 조회")
+  void getAllUsers_success_isDeletedNull() {
+    // Given
+    Page<User> userPage = new PageImpl<>(
+        Arrays.asList(user1, user2, user3),
+        PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "createdDate")),
+        3
+    );
+
+    when(userRepository.findAll(any(Pageable.class))).thenReturn(userPage);
+
+    // When
+    Page<UserResponseDto> result = userService.getAllUsers(null, 0, 10, "createdDate", true, null);
+
+    // Then
+    System.out.println("조회 결과 : " + result);
+    result.getContent().forEach(dto -> {
+      System.out.println("회원 이메일: " + dto.getUserEmail() + ", isDeleted: " + dto.getIsDeleted());
+    });
+
+    assertThat(result).hasSize(3);
+    assertEquals("user1@test.com", result.getContent().get(0).getUserEmail());
+    assertEquals("user2@test.com", result.getContent().get(1).getUserEmail());
+    assertEquals("user3@test.com", result.getContent().get(2).getUserEmail());
+  }
+
+  @Test
+  @DisplayName("전체 회원 조회 성공 테스트 - isDeleted가 false인 회원 조회")
+  void getAllUsers_success_isDeletedFalse() {
+    // Given
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "createdDate"));
+
+    when(userRepository.findByIsDeleted(eq(false), any(Pageable.class)))
+        .thenAnswer(invocation -> {
+          Pageable p = invocation.getArgument(1, Pageable.class);
+          // 전체 목록에서 isDeleted가 false인 회원만 필터링
+          var filtered = Arrays.asList(user1, user2, user3).stream()
+              .filter(user -> !Boolean.TRUE.equals(user.getIsDeleted()))
+              .toList();
+          return new PageImpl<>(filtered, p, filtered.size());
+        });
+
+    // When
+    Page<UserResponseDto> result = userService.getAllUsers(false, 0, 10, "createdDate", true, null);
+
+    // Then
+    System.out.println("조회 결과: " + result);
+    result.getContent().forEach(dto -> {
+      System.out.println("회원 이메일: " + dto.getUserEmail() + ", isDeleted: " + dto.getIsDeleted());
+    });
+
+    assertThat(result).hasSize(2);
+    assertEquals("user1@test.com", result.getContent().get(0).getUserEmail());
+    assertEquals("user3@test.com", result.getContent().get(1).getUserEmail());
+  }
+
+  @Test
+  @DisplayName("전체 회원 조회 성공 테스트 - isDeleted가 true안 회원 조회")
+  void getAllUsers_success_isDeletedTrue() {
+    // Given
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "createdDate"));
+
+    when(userRepository.findByIsDeleted(eq(true), any(Pageable.class)))
+        .thenAnswer(invocation -> {
+          Pageable p = invocation.getArgument(1, Pageable.class);
+          // 전체 목록에서 isDeleted가 true인 회원만 필터링
+          var filtered = Arrays.asList(user1, user2, user3).stream()
+              .filter(user -> !Boolean.FALSE.equals(user.getIsDeleted()))
+              .toList();
+          return new PageImpl<>(filtered, p, filtered.size());
+        });
+
+    // When
+    Page<UserResponseDto> result = userService.getAllUsers(false, 0, 10, "createdDate", true, null);
+
+    // Then
+    System.out.println("조회 결과: " + result);
+    result.getContent().forEach(dto -> {
+      System.out.println("회원 이메일: " + dto.getUserEmail() + ", isDeleted: " + dto.getIsDeleted());
+    });
+
+    assertThat(result).hasSize(1);
+    assertEquals("user2@test.com", result.getContent().get(0).getUserEmail());
+  }
+
+  @Test
+  @DisplayName("특정 권한을 가진 회원 조회 성공 테스트")
+  void getAllUsers_success_isRole() {
+    // Given
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "createdDate"));
+
+    when(userRepository.findByRole(eq(UserRoleEnum.CUSTOMER), any(Pageable.class)))
+        .thenAnswer(invocation -> {
+          Pageable p = invocation.getArgument(1, Pageable.class);
+          // 전체 목록에서 role이 CUSTOMER인 회원만 필터링
+          var filtered = Arrays.asList(user1, user2, user3).stream()
+              .filter(user -> user.getRole().equals(UserRoleEnum.CUSTOMER))
+              .toList();
+          return new PageImpl<>(filtered, p, filtered.size());
+        });
+
+    // When
+    Page<UserResponseDto> result = userService.getAllUsers(null, 0, 10, "createdDate", true, UserRoleEnum.CUSTOMER);
+
+    // Then
+    System.out.println("조회 결과: " + result);
+    result.getContent().forEach(dto -> {
+      System.out.println("회원 이메일: " + dto.getUserEmail() + ", role: " + dto.getRole());
+    });
+
+    assertThat(result).hasSize(2);
+    assertEquals("user1@test.com", result.getContent().get(0).getUserEmail());
+    assertEquals("user3@test.com", result.getContent().get(1).getUserEmail());
+  }
+
+  @Test
+  @DisplayName("특정 권한 & 탈퇴 여부 기반 회원 조회 성공 테스트")
+  void getAllUsers_success_isDeleted_isRole() {
+    // Given
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "createdDate"));
+
+    // isDeleted가 false이고, role이 CUSTOMER인 경우
+    when(userRepository.findByIsDeletedAndRole(eq(false), eq(UserRoleEnum.CUSTOMER), any(Pageable.class)))
+        .thenAnswer(invocation -> {
+          Pageable p = invocation.getArgument(2, Pageable.class);
+          // isDeleted가 false이고 role이 CUSTOMER인 회원만 필터링
+          var filtered = Arrays.asList(user1, user2, user3).stream()
+              .filter(user -> Boolean.FALSE.equals(user.getIsDeleted())
+                  && user.getRole().equals(UserRoleEnum.CUSTOMER))
+              .toList();
+          return new PageImpl<>(filtered, p, filtered.size());
+        });
+
+    // When
+    Page<UserResponseDto> result = userService.getAllUsers(false, 0, 10, "createdDate", true, UserRoleEnum.CUSTOMER);
+
+    // Then
+    System.out.println("조회 결과: " + result);
+    result.getContent().forEach(dto -> {
+      System.out.println("회원 이메일: " + dto.getUserEmail() + ", isDeleted: " + dto.getIsDeleted());
+    });
+
+    assertThat(result).hasSize(2);
+    assertEquals("user1@test.com", result.getContent().get(0).getUserEmail());
+    assertEquals("user3@test.com", result.getContent().get(1).getUserEmail());
+  }
+
+  @Test
+  @DisplayName("전체 회원 조회 실패 테스트- 전체 회원이 없을 경우")
+  void getAllUsers_empty() {
+    // Given
+    Page<User> emptyPage = new PageImpl<>(Collections.emptyList());
+    when(userRepository.findAll(any(Pageable.class))).thenReturn(emptyPage);
+
+    // When & Then
+    UserListNotFoundException exception = assertThrows(UserListNotFoundException.class,
+        () -> userService.getAllUsers(null, 0, 10, "createdDate", true, null));
+
+    System.out.println("Expected exception occurred: " + exception.getMessage());
+  }
+
+
+  @Test
+  @DisplayName("특정 회원 조회 성공 테스트")
+  void getUserByUserEmail_success() {
+    // Given
+    when(userRepository.findByUserEmail("user1@test.com")).thenReturn(Optional.of(user1));
+
+    // When
+    UserResponseDto dto = userService.getUserByUserEmail("user1@test.com");
+
+    // Then
+    System.out.println("회원 이메일: " + dto.getUserEmail());
+    assertEquals("user1@test.com", dto.getUserEmail());
+    assertEquals("user1", dto.getNickname());
+  }
+
+  @Test
+  @DisplayName("특정 회원 조회 실패 테스트 - 존재하지 않는 경우")
+  void getUserByUserEmail_notFound() {
+    // Given
+    when(userRepository.findByUserEmail(anyString())).thenReturn(Optional.empty());
+
+    // When & Then
+    UserNotFoundException exception = assertThrows(UserNotFoundException.class,
+        () -> userService.getUserByUserEmail("none@test.com"));
+
+    System.out.println("Expected exception occurred: " + exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("회원 정보 업데이트 - 성공")
+  void updateUser_success() {
+    // Given
+    when(userRepository.findById("user1@test.com")).thenReturn(Optional.of(user1));
+
+    UserUpdateRequestDto updateRequest = UserUpdateRequestDto.builder()
+        .password("newPass")
+        .nickname("newNick")
+        .phone("010-1111-2222")
+        .build();
+
+    when(passwordEncoder.encode("newPass")).thenReturn("encodedNewPass");
+    when(userRepository.existsByNickname("newNick")).thenReturn(false);
+
+    // When
+    UserResponseDto response = userService.updateUser("user1@test.com", updateRequest);
+
+    // Then
+    assertEquals("user1@test.com", response.getUserEmail());
+    assertEquals("newNick", response.getNickname());
+    assertEquals("010-1111-2222", response.getPhone());
+    System.out.println(
+        "업데이트 성공: " + response.getUserEmail() + ", " + response.getNickname() + ", " + response.getPhone());
+  }
+
+  @Test
+  @DisplayName("회원 정보 업데이트 - 필드가 빈값일 경우")
+  void updateUser_noUpdateFields() {
+    // Given
+    when(userRepository.findById("user1@test.com")).thenReturn(Optional.of(user1));
+
+    UserUpdateRequestDto updateRequest = UserUpdateRequestDto.builder()
+        .password("")
+        .nickname("")
+        .phone("")
+        .build();
+
+    // When & Then
+    UserNoFieldUpdatedException exception = assertThrows(UserNoFieldUpdatedException.class,
+        () -> userService.updateUser("user1@test.com", updateRequest));
+
+    System.out.println("Expected exception occurred: " + exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("회원 정보 업데이트 - 닉네임 중복 시 실패")
+  void updateUser_duplicateNickname() {
+    // Given
+    when(userRepository.findById("user1@test.com")).thenReturn(Optional.of(user1));
+
+    UserUpdateRequestDto updateRequest = UserUpdateRequestDto.builder()
+        .nickname("duplicateNick")
+        .build();
+    when(userRepository.existsByNickname("duplicateNick")).thenReturn(true);
+
+    // When & Then
+    UserDuplicateNicknameException exception = assertThrows(UserDuplicateNicknameException.class,
+        () -> userService.updateUser("user1@test.com", updateRequest));
+
+    System.out.println("Expected exception occurred: " + exception.getMessage());
+  }
+
+
+  @Test
+  @DisplayName("회원 탈퇴 - 성공")
+  void softDeleteUser_success() {
+    // Given
+    when(userRepository.findByUserEmail("user1@test.com")).thenReturn(Optional.of(user1));
+
+    // When
+    userService.softDeleteUser("user1@test.com", "user1@test.com");
+
+    // Then
+    verify(userRepository).findByUserEmail("user1@test.com");
+    assertTrue(user1.getIsDeleted());
+    System.out.println("회원 탈퇴 후 isDeleted: " + true);
+  }
+
+}


### PR DESCRIPTION
## ⚙️ PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 🔑 Key Changes
- Redis와의 연결과 데이터 처리에 사용할 `RedisTemplate`을 빈으로 등록했습니다.
- `RedisRepositoryConfig.java`는 Refresh Token과 블랙리스트 토큰을 Redis에 저장하고 조회할 수 있도록 설정하기 위해 작성했습니다.
- `CacheConfig.java`는 사용자 정보를 캐시에 저장하여 로그인 시 빠른 인증 처리와 DB 부하 감소를 위해 작성했습니다.

- 로그인 시 Redis에 토큰 저장
  - `JwtUtil`을 사용하여 Access Token과 Refresh Token을 생성했습니다.
  - Refresh Token을 Redis에 저장했습니다.
    - Key: "RT:" + userEmail / Value: Refresh Token / TTL: Refresh Token 만료 시간만큼 설정

- 로그아웃 시 Redis 블랙리스트 처리
  - 저장된 Refresh Token을 삭제하여 재발급 요청을 차단했습니다. 
  - 사용 중인 Access Token을 블랙리스트에 등록하여 토큰 무효화 처리했습니다.
  - Access Token의 남은 유효시간만큼 Redis에 저장했습니다.
  - 토큰 만료 전이라도 Redis에 등록된 경우 무효 토큰 처리 가능하도록 했습니다.
  - 로그아웃 후 해당 Access Token의 재사용을 방지했습니다.

- JWT 필터 수정 (`JwtAuthorizationFilter`)
  - Access Token 유효성 검증 기능을 추가했습니다.
  - Redis에서 블랙리스트 여부를 확인할 수 있도록 했습니다.
    - 블랙리스트에 있으면 → 요청 차단 및 에러 반환
    - 없으면 → 정상 인증 처리

- Refresh Token 재발급 기능 추가
  - 클라이언트로부터 Refresh Token을 추출 및 검증하도록 했습니다.
  - Redis에 저장된 토큰과 요청 토큰을 비교했습니다.
  - 검증 성공 시 새 토큰 발급 및 Redis 업데이트:
    - 새 Access Token & Refresh Token 발급
    - Redis에 새 Refresh Token 저장 (TTL 설정)
    - 새 Refresh Token은 쿠키에 추가하여 클라이언트에 전달

<br/>

## 🤝🏻 To Reviewers

-

<br/>

